### PR TITLE
 feat(settlement): log settlement completion with proceeds and investor count

### DIFF
--- a/src/lib/settlement-completion-log.ts
+++ b/src/lib/settlement-completion-log.ts
@@ -1,0 +1,27 @@
+import type { AppLogger } from "../observability/logger";
+import { stroopsToXlm } from "./stellar-format";
+
+export interface SettlementCompletionLogInput {
+  invoiceId: string;
+  /** Total settled proceeds expressed in stroops, formatted to XLM via stroopsToXlm before logging. */
+  totalProceedsStroops: bigint;
+  investorCount: number;
+}
+
+/**
+ * Emits the settlement flow completion audit log. Callers must invoke this
+ * only after every investor's return has been recorded and the invoice
+ * status has been updated to settled — never on a partial or failed
+ * settlement, which error logging handles instead.
+ */
+export function logSettlementCompletion(
+  logger: AppLogger,
+  input: SettlementCompletionLogInput,
+): void {
+  logger.info("Settlement flow completed.", {
+    invoice_id: input.invoiceId,
+    total_proceeds: stroopsToXlm(input.totalProceedsStroops),
+    investor_count: input.investorCount,
+    settled_at: new Date().toISOString(),
+  });
+}

--- a/src/services/settlement.service.ts
+++ b/src/services/settlement.service.ts
@@ -7,7 +7,14 @@ import { ServiceError } from "../utils/service-error";
 import { computeInvestorReturn } from "../lib/investor-return";
 import { decimalStringToScaledBigInt, scaledBigIntToDecimalString } from "../lib/decimal-bigint";
 import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
+import { logSettlementCompletion } from "../lib/settlement-completion-log";
 import { logger } from "../observability/logger";
+
+// settlement.service.ts stores/computes amounts as decimal strings scaled by
+// 10^4 (see decimal-bigint.ts), while stroopsToXlm expects a stroops count
+// (10^7 scale). Multiplying by 10^3 converts between the two without any
+// loss of precision, since 7 - 4 = 3.
+const DECIMAL_SCALE_TO_STROOP_FACTOR = 10n ** 3n;
 
 export interface SettleInvoiceInput {
   invoiceId: string;
@@ -119,6 +126,12 @@ export class SettlementService {
         toState: InvoiceStatus.SETTLED,
         actorWallet,
         reason: "admin_settled",
+      });
+
+      logSettlementCompletion(logger, {
+        invoiceId: invoice.id,
+        totalProceedsStroops: proceedsScaled * DECIMAL_SCALE_TO_STROOP_FACTOR,
+        investorCount: settlements.length,
       });
 
       return {

--- a/tests/integration/settlement.integration.test.ts
+++ b/tests/integration/settlement.integration.test.ts
@@ -5,6 +5,7 @@ import { SettlementService } from "../../src/services/settlement.service";
 import { Invoice } from "../../src/models/Invoice.model";
 import { Investment } from "../../src/models/Investment.model";
 import { InvoiceStatus, InvestmentStatus } from "../../src/types/enums";
+import { logger } from "../../src/observability/logger";
 
 /**
  * Minimal in-memory TypeORM stand-in shared by InvestmentService and
@@ -107,6 +108,10 @@ function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
 }
 
 describe("Settlement integration: funding multiple investors then settling", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("distributes proceeds pro-rata to each investor and marks the invoice settled", async () => {
     const invoice = createInvoice();
     const { dataSource, invoices, investments } = createFakeDataSource(invoice);
@@ -163,5 +168,77 @@ describe("Settlement integration: funding multiple investors then settling", () 
       0,
     );
     expect(sumOfReturns).toBeCloseTo(6600, 4);
+  });
+
+  it("logs settlement completion with the correct invoice_id, total_proceeds, and investor_count", async () => {
+    const infoSpy = jest.spyOn(logger, "info");
+
+    const invoice = createInvoice();
+    const { dataSource, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    const investorAId = crypto.randomUUID();
+    const investorBId = crypto.randomUUID();
+
+    const investmentA = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorAId,
+      investmentAmount: "4000.0000",
+      investorWallet: "GINVESTORA1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    });
+    const investmentB = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorBId,
+      investmentAmount: "2000.0000",
+      investorWallet: "GINVESTORB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    });
+
+    for (const investment of [investmentA, investmentB]) {
+      const stored = investments.get(investment.id)!;
+      stored.status = InvestmentStatus.CONFIRMED;
+      investments.set(investment.id, stored);
+    }
+
+    await settlementService.settleInvoice({
+      invoiceId: invoice.id,
+      proceeds: "6600.0000",
+      actorWallet: "GADMINWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    });
+
+    const completionCall = infoSpy.mock.calls.find(
+      ([message]) => message === "Settlement flow completed.",
+    );
+    expect(completionCall).toBeDefined();
+
+    const metadata = completionCall?.[1] as Record<string, unknown>;
+    expect(metadata.invoice_id).toBe(invoice.id);
+    expect(metadata.total_proceeds).toBe("6600.0000000");
+    expect(metadata.investor_count).toBe(2);
+    expect(metadata.settled_at).toEqual(expect.any(String));
+  });
+
+  it("does not log settlement completion when settlement fails", async () => {
+    const infoSpy = jest.spyOn(logger, "info");
+
+    // Invoice is still PUBLISHED (never funded), so settlement must fail
+    // before any investor returns are recorded.
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource } = createFakeDataSource(invoice);
+    const settlementService = new SettlementService(dataSource);
+
+    await expect(
+      settlementService.settleInvoice({
+        invoiceId: invoice.id,
+        proceeds: "6600.0000",
+        actorWallet: "GADMINWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      }),
+    ).rejects.toThrow();
+
+    const completionCall = infoSpy.mock.calls.find(
+      ([message]) => message === "Settlement flow completed.",
+    );
+    expect(completionCall).toBeUndefined();
   });
 });

--- a/tests/settlement-completion-log.test.ts
+++ b/tests/settlement-completion-log.test.ts
@@ -1,0 +1,61 @@
+import { logSettlementCompletion } from "../src/lib/settlement-completion-log";
+import type { AppLogger } from "../src/observability/logger";
+
+function createMockLogger(): jest.Mocked<AppLogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  } as unknown as jest.Mocked<AppLogger>;
+}
+
+describe("logSettlementCompletion", () => {
+  it("emits an info log with all four required fields, formatting proceeds in XLM via stroopsToXlm", () => {
+    const logger = createMockLogger();
+
+    logSettlementCompletion(logger, {
+      invoiceId: "invoice-123",
+      totalProceedsStroops: 12_345_000_0000n, // 12,345 XLM
+      investorCount: 3,
+    });
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Settlement flow completed.",
+      expect.objectContaining({
+        invoice_id: "invoice-123",
+        total_proceeds: "12345.0000000",
+        investor_count: 3,
+        settled_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("formats fractional stroop amounts to full XLM precision", () => {
+    const logger = createMockLogger();
+
+    logSettlementCompletion(logger, {
+      invoiceId: "invoice-456",
+      totalProceedsStroops: 1n, // smallest possible unit
+      investorCount: 1,
+    });
+
+    const metadata = logger.info.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(metadata.total_proceeds).toBe("0.0000001");
+  });
+
+  it("settled_at is a valid ISO timestamp", () => {
+    const logger = createMockLogger();
+
+    logSettlementCompletion(logger, {
+      invoiceId: "invoice-789",
+      totalProceedsStroops: 10_000_000n,
+      investorCount: 2,
+    });
+
+    const metadata = logger.info.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(new Date(metadata.settled_at as string).toISOString()).toBe(metadata.settled_at);
+  });
+});


### PR DESCRIPTION
## Description

Closes #62. Adds an info-level log emitted when a settlement completes successfully, so operators get an audit trail without having to query the database.

Operators previously had no way to see settlement outcomes short of a DB query. The only related log was the generic invoice lifecycle transition log, which doesn't capture proceeds or investor count.

Added `logSettlementCompletion`, mirroring the existing `logInvoiceTransition` pattern in `lib/invoice-lifecycle-log.ts`. It's wired into `SettlementService.settleInvoice`, right after the invoice is saved as `SETTLED`, at the same point the existing transition log already fires. That means it never logs on a partial or failed settlement, since those cases throw before reaching that point and are left to error logging.

One thing worth calling out for reviewers: `settlement.service.ts` represents amounts as decimal strings scaled by 10^4 (see `decimal-bigint.ts`), not raw stroops. So `proceedsScaled` gets converted to a stroops-equivalent bigint (multiplied by 10^3, since 7 minus 4 is 3) before being passed through `stroopsToXlm` for the `total_proceeds` field. This follows the issue's requirement to use that helper rather than log raw stroops directly. `investor_count` is `settlements.length`, which is exactly the investors who received a computed `actualReturn` in that settlement run.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [x] ✅ Test addition or update
- [ ] 🔧 Configuration change

## Checklist

- [x] **All GitHub Actions workflows are green** on this PR (required for merge)
- [x] Commit messages follow **Conventional Commits** (`feat:`, `fix:`, `chore:`, etc.) — enforced by CI
- [x] No secrets, API keys, `.env`, or credentials committed (see `CONTRIBUTING.md`)
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing

### How to Test

1. Run `npx jest tests/settlement-completion-log.test.ts tests/integration/settlement.integration.test.ts` to run the new tests directly.
2. Or run the full suite with `npx jest` to confirm nothing else broke.
3. To see the log in a running instance, settle a funded invoice and check the console output for a "Settlement flow completed." entry with `invoice_id`, `total_proceeds`, `investor_count`, and `settled_at`.

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manual testing completed

Added unit tests for `logSettlementCompletion`'s field shape and XLM formatting, plus two integration tests confirming the real `settleInvoice()` flow logs the correct `invoice_id`, `total_proceeds`, and `investor_count` on success, and logs nothing at all when settlement fails before completion. I also verified the integration test actually catches a regression: temporarily removed the log call, reran the tests to confirm it failed, then restored it.

Full suite: 235 passed, 0 failed. Build and lint both clean.

## Additional Notes

No documentation changes needed since this is an internal log line, not a public API change.

## For Reviewers

- [x] Code quality and readability
- [x] Test coverage
- [ ] Security implications
- [ ] Performance impact
- [ ] Breaking changes

The stroops-vs-decimal-scale conversion is the part most worth a careful look, since a wrong scale factor there would silently produce a `total_proceeds` value off by orders of magnitude without any test failure elsewhere.