### PR TITLE
Add invoice funding notifications integration coverage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export async function bootstrap(): Promise<{ server: Server }> {
   const notificationService = createNotificationService(dataSource);
   const ipfsService = createIPFSService(config.ipfs, logger);
   const invoiceService = createInvoiceService(dataSource, ipfsService);
-  const investmentService = createInvestmentService(dataSource);
+  const investmentService = createInvestmentService(dataSource, notificationService);
   const settlementService = createSettlementService(dataSource);
   const marketplaceService = createMarketplaceService(dataSource);
 

--- a/src/services/investment.service.ts
+++ b/src/services/investment.service.ts
@@ -6,6 +6,8 @@ import { ServiceError } from "../utils/service-error";
 import { Decimal } from "decimal.js";
 import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
 import { logger } from "../observability/logger";
+import { NotificationType } from "../types/enums";
+import type { NotificationService } from "./notification.service";
 
 // Formula for expected return:
 // Investor's share of the invoice face value (amount) proportional to their contribution to the fundable amount (netAmount).
@@ -27,8 +29,16 @@ export interface InvestorDashboard {
 
 const ACTIVE_INVESTMENT_STATUSES = [InvestmentStatus.PENDING, InvestmentStatus.CONFIRMED];
 
+interface CreateInvestmentResult {
+  savedInvestment: Investment;
+  fundedInvoiceId?: string;
+}
+
 export class InvestmentService {
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly notificationService?: NotificationService,
+  ) {}
 
   /**
    * Aggregates an investor's portfolio across all their investments.
@@ -80,7 +90,8 @@ export class InvestmentService {
       throw new ServiceError("INVALID_AMOUNT", "Investment amount must be greater than zero");
     }
 
-    return await this.dataSource.transaction(async (transactionalEntityManager: EntityManager) => {
+    const result = await this.dataSource.transaction(
+      async (transactionalEntityManager: EntityManager): Promise<CreateInvestmentResult> => {
       // 1. Lock the invoice row for update
       const invoice = await transactionalEntityManager
         .createQueryBuilder(Invoice, "invoice")
@@ -107,7 +118,7 @@ export class InvestmentService {
 
       // 4. Check remaining capacity
       // We count both PENDING and CONFIRMED investments towards the cap to prevent over-subscription
-      const activeInvestments = await transactionalEntityManager.find(Investment, {
+      const activeInvestments: Investment[] = await transactionalEntityManager.find(Investment, {
         where: [
           { invoiceId, status: InvestmentStatus.PENDING },
           { invoiceId, status: InvestmentStatus.CONFIRMED },
@@ -115,7 +126,7 @@ export class InvestmentService {
       });
 
       const totalInvested = activeInvestments.reduce(
-        (sum, inv) => sum.plus(new Decimal(inv.investmentAmount)),
+        (sum: Decimal, inv: Investment) => sum.plus(new Decimal(inv.investmentAmount)),
         new Decimal(0),
       );
 
@@ -159,13 +170,59 @@ export class InvestmentService {
           actorWallet: investorWallet,
           reason: "fully_funded",
         });
+
+        return { savedInvestment, fundedInvoiceId: invoice.id };
       }
 
-      return savedInvestment;
+      return { savedInvestment };
+      },
+    );
+
+    if (result.fundedInvoiceId) {
+      await this.notifyInvoiceFullyFunded(result.fundedInvoiceId);
+    }
+
+    return result.savedInvestment;
+  }
+
+  async notifyInvoiceFullyFunded(invoiceId: string): Promise<void> {
+    if (!this.notificationService) {
+      return;
+    }
+
+    const invoice = await this.dataSource.getRepository(Invoice).findOne({
+      where: { id: invoiceId },
     });
+
+    if (!invoice || invoice.status !== InvoiceStatus.FUNDED) {
+      return;
+    }
+
+    const investments = await this.dataSource.getRepository(Investment).find({
+      where: { invoiceId },
+    });
+
+    const fundedAmount = new Decimal(invoice.netAmount).toFixed(4);
+    const title = "Invoice fully funded";
+    const message = `Invoice ${invoice.invoiceNumber} has been fully funded for ${fundedAmount}.`;
+    const recipientIds = new Set<string>(
+      [invoice.sellerId, ...investments.map((investment: Investment) => investment.investorId)],
+    );
+
+    for (const recipientId of recipientIds) {
+      await this.notificationService.createNotificationIfNotExists(
+        recipientId,
+        NotificationType.INVOICE,
+        title,
+        message,
+      );
+    }
   }
 }
 
-export function createInvestmentService(dataSource: DataSource): InvestmentService {
-  return new InvestmentService(dataSource);
+export function createInvestmentService(
+  dataSource: DataSource,
+  notificationService?: NotificationService,
+): InvestmentService {
+  return new InvestmentService(dataSource, notificationService);
 }

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -29,6 +29,12 @@ export interface NotificationRepositoryContract {
     title: string,
     message: string,
   ): Promise<Notification>;
+  findByContent(
+    userId: string,
+    type: NotificationType,
+    title: string,
+    message: string,
+  ): Promise<Notification | null>;
   findByIdAndUserId(id: string, userId: string): Promise<Notification | null>;
   markRead(id: string, userId: string): Promise<Notification>;
   list(options: ListNotificationsOptions): Promise<NotificationPage>;
@@ -52,6 +58,26 @@ export class NotificationService {
     title: string,
     message: string,
   ): Promise<Notification> {
+    return this.notificationRepository.create(userId, type, title, message);
+  }
+
+  async createNotificationIfNotExists(
+    userId: string,
+    type: NotificationType,
+    title: string,
+    message: string,
+  ): Promise<Notification> {
+    const existingNotification = await this.notificationRepository.findByContent(
+      userId,
+      type,
+      title,
+      message,
+    );
+
+    if (existingNotification) {
+      return existingNotification;
+    }
+
     return this.notificationRepository.create(userId, type, title, message);
   }
 
@@ -93,6 +119,15 @@ class TypeOrmNotificationRepository implements NotificationRepositoryContract {
   ): Promise<Notification> {
     const entity = this.repository.create({ userId, type, title, message });
     return this.repository.save(entity);
+  }
+
+  findByContent(
+    userId: string,
+    type: NotificationType,
+    title: string,
+    message: string,
+  ): Promise<Notification | null> {
+    return this.repository.findOne({ where: { userId, type, title, message } });
   }
 
   findByIdAndUserId(id: string, userId: string): Promise<Notification | null> {

--- a/tests/integration/invoice-funding-notifications.integration.test.ts
+++ b/tests/integration/invoice-funding-notifications.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { DataSource } from "typeorm";
+import { Notification } from "../../src/models/Notification.model";
+import { Invoice } from "../../src/models/Invoice.model";
+import { Investment } from "../../src/models/Investment.model";
+import { User } from "../../src/models/User.model";
+import { createNotificationService } from "../../src/services/notification.service";
+import { InvestmentService } from "../../src/services/investment.service";
+import { InvoiceStatus, KYCStatus, NotificationType, UserType } from "../../src/types/enums";
+
+describe("Invoice funding notifications integration", () => {
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      console.warn("DATABASE_URL not set, skipping integration tests");
+      return;
+    }
+
+    dataSource = new DataSource({
+      type: "postgres",
+      url: databaseUrl,
+      entities: [User, Invoice, Investment, Notification],
+      synchronize: true,
+      logging: false,
+      dropSchema: true,
+    });
+
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    if (dataSource && dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("creates notifications for each committed investor and the seller when an invoice is funded", async () => {
+    if (!dataSource || !dataSource.isInitialized) {
+      console.warn("Skipping test - DATABASE_URL not configured");
+      return;
+    }
+
+    const userRepository = dataSource.getRepository(User);
+    const invoiceRepository = dataSource.getRepository(Invoice);
+    const notificationRepository = dataSource.getRepository(Notification);
+
+    const seller = await userRepository.save(
+      userRepository.create({
+        stellarAddress: "GSELLERNOTIFY1234567890ABCDEFGHIJKLMNOPQRST",
+        email: "seller-notify@test.com",
+        userType: UserType.SELLER,
+        kycStatus: KYCStatus.APPROVED,
+      }),
+    );
+
+    const investorA = await userRepository.save(
+      userRepository.create({
+        stellarAddress: "GINVESTORNOTIFYA1234567890ABCDEFGHIJKLMNOPQ",
+        email: "investor-a@test.com",
+        userType: UserType.INVESTOR,
+        kycStatus: KYCStatus.APPROVED,
+      }),
+    );
+
+    const investorB = await userRepository.save(
+      userRepository.create({
+        stellarAddress: "GINVESTORNOTIFYB1234567890ABCDEFGHIJKLMNOPQ",
+        email: "investor-b@test.com",
+        userType: UserType.INVESTOR,
+        kycStatus: KYCStatus.APPROVED,
+      }),
+    );
+
+    const invoice = await invoiceRepository.save(
+      invoiceRepository.create({
+        sellerId: seller.id,
+        invoiceNumber: "INV-NOTIFY-001",
+        customerName: "Notify Customer",
+        amount: "1000.0000",
+        discountRate: "10.00",
+        netAmount: "900.0000",
+        dueDate: new Date("2025-12-31"),
+        status: InvoiceStatus.PUBLISHED,
+      }),
+    );
+
+    const notificationService = createNotificationService(dataSource);
+    const investmentService = new InvestmentService(dataSource, notificationService);
+
+    await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorA.id,
+      investmentAmount: "450.0000",
+      investorWallet: investorA.stellarAddress,
+    });
+
+    await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorB.id,
+      investmentAmount: "450.0000",
+      investorWallet: investorB.stellarAddress,
+    });
+
+    const fundedInvoice = await invoiceRepository.findOne({ where: { id: invoice.id } });
+    expect(fundedInvoice?.status).toBe(InvoiceStatus.FUNDED);
+
+    const investorANotifications = await notificationRepository.find({ where: { userId: investorA.id } });
+    const investorBNotifications = await notificationRepository.find({ where: { userId: investorB.id } });
+    const sellerNotifications = await notificationRepository.find({ where: { userId: seller.id } });
+
+    expect(investorANotifications).toHaveLength(1);
+    expect(investorBNotifications).toHaveLength(1);
+    expect(sellerNotifications).toHaveLength(1);
+
+    for (const notification of [...investorANotifications, ...investorBNotifications, ...sellerNotifications]) {
+      expect(notification.type).toBe(NotificationType.INVOICE);
+      expect(notification.title).toBe("Invoice fully funded");
+      expect(notification.message).toContain(invoice.invoiceNumber);
+      expect(notification.message).toContain("900.0000");
+    }
+
+    const notificationCountBeforeReplay = await notificationRepository.count();
+
+    await investmentService.notifyInvoiceFullyFunded(invoice.id);
+
+    const reloadedInvestorANotifications = await notificationRepository.find({ where: { userId: investorA.id } });
+    const reloadedInvestorBNotifications = await notificationRepository.find({ where: { userId: investorB.id } });
+    const reloadedSellerNotifications = await notificationRepository.find({ where: { userId: seller.id } });
+    const notificationCountAfterReplay = await notificationRepository.count();
+
+    expect(reloadedInvestorANotifications).toHaveLength(1);
+    expect(reloadedInvestorBNotifications).toHaveLength(1);
+    expect(reloadedSellerNotifications).toHaveLength(1);
+    expect(notificationCountAfterReplay).toBe(notificationCountBeforeReplay);
+  });
+});


### PR DESCRIPTION
Closes #63

Adds end-to-end coverage for invoice-funding notifications and wires the funding path to create them.

It updates the investment funding flow to notify each committed investor and the seller when an invoice transitions to funded, and it keeps repeated notification emission idempotent by skipping exact duplicates. It also adds a DB-backed integration test that seeds a seller plus two investors, funds the invoice, verifies the notification records and message content, and confirms a second funded notification pass does not create duplicates.