### PR TITLE
feat: issues #83, #84, #85, #86 — investment log, notification test, JWT helper, invoice search

### DIFF
--- a/src/controllers/marketplace.controller.ts
+++ b/src/controllers/marketplace.controller.ts
@@ -17,6 +17,7 @@ const getInvoicesSchema = Joi.object({
   maxAmount: Joi.number().min(0).optional(),
   sort: Joi.string().valid("due_date", "discount_rate", "amount", "created_at").default("due_date"),
   sortOrder: Joi.string().valid("ASC", "DESC").default("ASC"),
+  search: Joi.string().trim().max(255).optional(),
 });
 
 export interface GetInvoicesRequest extends Request {
@@ -58,6 +59,7 @@ export function createMarketplaceController(marketplaceService: MarketplaceServi
           maxAmount: value.maxAmount,
           sort: value.sort,
           sortOrder: value.sortOrder,
+          search: value.search,
         };
 
         // Validate amount range

--- a/src/lib/extract-wallet-from-token.ts
+++ b/src/lib/extract-wallet-from-token.ts
@@ -1,0 +1,29 @@
+import jwt from "jsonwebtoken";
+
+/**
+ * Safely extracts the wallet address (sub claim) from a JWT token.
+ *
+ * Returns the `sub` claim string on a valid, unexpired token.
+ * Returns null for: missing token, expired token, invalid signature,
+ * missing `sub` claim. Never throws.
+ */
+export function extractWalletFromToken(
+  token: string | undefined,
+  secret: string,
+): string | null {
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as jwt.JwtPayload;
+
+    if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+      return null;
+    }
+
+    return payload.sub;
+  } catch {
+    return null;
+  }
+}

--- a/src/services/investment.service.ts
+++ b/src/services/investment.service.ts
@@ -6,6 +6,7 @@ import { ServiceError } from "../utils/service-error";
 import { Decimal } from "decimal.js";
 import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
 import { logger } from "../observability/logger";
+import { stroopsToXlm } from "../lib/stellar-format";
 
 // Formula for expected return:
 // Investor's share of the invoice face value (amount) proportional to their contribution to the fundable amount (netAmount).
@@ -145,7 +146,23 @@ export class InvestmentService {
 
       const savedInvestment = await transactionalEntityManager.save(Investment, investment);
 
-      // 7. Transition invoice to FUNDED if fully subscribed
+      // 7. Emit structured log for the investment commitment
+      const truncatedWallet =
+        investorWallet.length >= 8
+          ? `${investorWallet.slice(0, 4)}…${investorWallet.slice(-4)}`
+          : investorWallet;
+      const sharePercent = amount.dividedBy(netAmount).times(100).toFixed(2);
+
+      logger.info("investment.committed", {
+        investment_id: savedInvestment.id,
+        invoice_id: invoiceId,
+        investor_wallet: truncatedWallet,
+        amount_xlm: stroopsToXlm(BigInt(amount.times(10_000_000).toFixed(0))),
+        share_percent: sharePercent,
+        committed_at: savedInvestment.createdAt?.toISOString() ?? new Date().toISOString(),
+      });
+
+      // 8. Transition invoice to FUNDED if fully subscribed
       const newTotalInvested = totalInvested.plus(amount);
       if (newTotalInvested.gte(netAmount)) {
         const previousStatus = invoice.status;

--- a/src/services/marketplace.service.ts
+++ b/src/services/marketplace.service.ts
@@ -9,6 +9,7 @@ export interface MarketplaceFilters {
   maxAmount?: number;
   sort?: "due_date" | "discount_rate" | "amount" | "created_at";
   sortOrder?: "ASC" | "DESC";
+  search?: string;
 }
 
 export interface PaginationOptions {
@@ -69,6 +70,7 @@ export class MarketplaceService {
       maxAmount: filters.maxAmount,
       sort: filters.sort || "due_date",
       sortOrder: filters.sortOrder || "ASC",
+      search: filters.search,
     };
 
     // Validate pagination
@@ -149,6 +151,13 @@ class TypeORMMarketplaceRepository implements MarketplaceRepositoryContract {
     if (filters.maxAmount !== undefined) {
       queryBuilder.andWhere("CAST(invoice.amount AS DECIMAL) <= :maxAmount", {
         maxAmount: filters.maxAmount,
+      });
+    }
+
+    // Apply search filter (case-insensitive match on customer_name)
+    if (filters.search) {
+      queryBuilder.andWhere("LOWER(invoice.customer_name) LIKE :search", {
+        search: `%${filters.search.toLowerCase()}%`,
       });
     }
 

--- a/tests/integration/invoice-search.integration.test.ts
+++ b/tests/integration/invoice-search.integration.test.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { MarketplaceService, MarketplaceRepositoryContract } from "../../src/services/marketplace.service";
+import { Invoice } from "../../src/models/Invoice.model";
+import { InvoiceStatus } from "../../src/types/enums";
+
+/**
+ * In-memory repository that implements case-insensitive search on
+ * customer_name, mirroring the real TypeORM repository's LIKE filter.
+ */
+function createFakeMarketplaceRepository(invoices: Invoice[]): MarketplaceRepositoryContract {
+  return {
+    async findPublishedInvoices(filters) {
+      const statuses = filters.status && filters.status.length > 0 ? filters.status : [InvoiceStatus.PUBLISHED];
+      let matched = invoices.filter((invoice) => statuses.includes(invoice.status));
+
+      if (filters.search) {
+        const term = filters.search.toLowerCase();
+        matched = matched.filter((inv) =>
+          inv.customerName.toLowerCase().includes(term),
+        );
+      }
+
+      return { invoices: matched, total: matched.length };
+    },
+  };
+}
+
+function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: crypto.randomUUID(),
+    sellerId: crypto.randomUUID(),
+    invoiceNumber: `INV-${crypto.randomUUID().slice(0, 8)}`,
+    customerName: "Customer",
+    amount: "1000.0000",
+    discountRate: "5.00",
+    netAmount: "950.0000",
+    dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    ipfsHash: "QmTestHash",
+    riskScore: null,
+    status: InvoiceStatus.PUBLISHED,
+    smartContractId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    seller: undefined as unknown as Invoice["seller"],
+    investments: [],
+    transactions: [],
+    ...overrides,
+  } as Invoice;
+}
+
+describe("Invoice search: partial title match (case-insensitive)", () => {
+  const alphaInvoice = createInvoice({ customerName: "Alpha Invoice" });
+  const betaSupply = createInvoice({ customerName: "Beta Supply" });
+  const alphaProject = createInvoice({ customerName: "Alpha project supplies" });
+
+  const allInvoices = [alphaInvoice, betaSupply, alphaProject];
+
+  let service: MarketplaceService;
+
+  beforeEach(() => {
+    service = new MarketplaceService({
+      marketplaceRepository: createFakeMarketplaceRepository(allInvoices),
+    });
+  });
+
+  it("returns two invoices when searching for 'alpha' (title match)", async () => {
+    const result = await service.getPublishedInvoices({ search: "alpha" });
+    expect(result.data).toHaveLength(2);
+    const names = result.data.map((i) => i.customerName);
+    expect(names).toContain("Alpha Invoice");
+    expect(names).toContain("Alpha project supplies");
+  });
+
+  it("returns one invoice when searching for 'beta'", async () => {
+    const result = await service.getPublishedInvoices({ search: "beta" });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].customerName).toBe("Beta Supply");
+  });
+
+  it("returns empty array for no-match search with 200-style response", async () => {
+    const result = await service.getPublishedInvoices({ search: "zzznomatch" });
+    expect(result.data).toHaveLength(0);
+    expect(result.meta.total).toBe(0);
+  });
+
+  it("search is case-insensitive", async () => {
+    const result = await service.getPublishedInvoices({ search: "ALPHA" });
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("returns all invoices when no search term is provided", async () => {
+    const result = await service.getPublishedInvoices({});
+    expect(result.data).toHaveLength(3);
+  });
+});

--- a/tests/integration/notification-mark-read.integration.test.ts
+++ b/tests/integration/notification-mark-read.integration.test.ts
@@ -1,0 +1,130 @@
+import crypto from "crypto";
+import { NotificationService, NotificationRepositoryContract, NotificationPage } from "../../src/services/notification.service";
+import { NotificationType } from "../../src/types/enums";
+
+interface StoredNotification {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  read: boolean;
+  timestamp: Date;
+}
+
+/**
+ * In-memory notification repository for integration testing.
+ */
+function createFakeNotificationRepository(): NotificationRepositoryContract & { store: StoredNotification[] } {
+  const store: StoredNotification[] = [];
+
+  return {
+    store,
+
+    async create(userId, type, title, message) {
+      const notif: StoredNotification = {
+        id: crypto.randomUUID(),
+        userId,
+        type,
+        title,
+        message,
+        read: false,
+        timestamp: new Date(),
+      };
+      store.push(notif);
+      return notif as import("../../src/models/Notification.model").Notification;
+    },
+
+    async findByIdAndUserId(id, userId) {
+      return (store.find((n) => n.id === id && n.userId === userId) ?? null) as import("../../src/models/Notification.model").Notification | null;
+    },
+
+    async markRead(id, userId) {
+      const notif = store.find((n) => n.id === id && n.userId === userId);
+      if (!notif) throw new Error("Not found");
+      notif.read = true;
+      return notif as import("../../src/models/Notification.model").Notification;
+    },
+
+    async list(options) {
+      let filtered = store.filter((n) => n.userId === options.userId);
+      if (options.read !== undefined) {
+        filtered = filtered.filter((n) => n.read === options.read);
+      }
+      const page = options.page ?? 1;
+      const limit = options.limit ?? 20;
+      return {
+        data: filtered.slice((page - 1) * limit, page * limit) as import("../../src/models/Notification.model").Notification[],
+        meta: { total: filtered.length, page, limit, totalPages: Math.ceil(filtered.length / limit) },
+      };
+    },
+  };
+}
+
+describe("Notification mark-as-read integration", () => {
+  let repo: ReturnType<typeof createFakeNotificationRepository>;
+  let service: NotificationService;
+
+  beforeEach(() => {
+    repo = createFakeNotificationRepository();
+    service = new NotificationService(repo);
+  });
+
+  it("marks a notification as read and persists the status", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.INVOICE,
+      "Invoice published",
+      "Your invoice has been published.",
+    );
+
+    expect(notif.read).toBe(false);
+
+    const marked = await service.markNotificationRead(notif.id, "wallet-1");
+    expect(marked.read).toBe(true);
+
+    // Verify persistence via the store
+    const stored = repo.store.find((n) => n.id === notif.id);
+    expect(stored?.read).toBe(true);
+  });
+
+  it("unread count decrements after marking as read", async () => {
+    await service.createNotification("wallet-1", NotificationType.INVOICE, "A", "a");
+    await service.createNotification("wallet-1", NotificationType.INVESTMENT, "B", "b");
+
+    const before = await service.listNotifications({ userId: "wallet-1", read: false });
+    expect(before.meta.total).toBe(2);
+
+    await service.markNotificationRead(repo.store[0].id, "wallet-1");
+
+    const after = await service.listNotifications({ userId: "wallet-1", read: false });
+    expect(after.meta.total).toBe(1);
+  });
+
+  it("marking an already-read notification is idempotent", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.PAYMENT,
+      "Settlement",
+      "Settlement complete.",
+    );
+
+    await service.markNotificationRead(notif.id, "wallet-1");
+    const second = await service.markNotificationRead(notif.id, "wallet-1");
+
+    expect(second.read).toBe(true);
+  });
+
+  it("cannot mark a notification belonging to another wallet", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.INVOICE,
+      "Invoice",
+      "desc",
+    );
+
+    await expect(
+      service.markNotificationRead(notif.id, "wallet-2"),
+    ).rejects.toThrow("Notification not found");
+  });
+});

--- a/tests/unit/extract-wallet-from-token.test.ts
+++ b/tests/unit/extract-wallet-from-token.test.ts
@@ -1,0 +1,49 @@
+import jwt from "jsonwebtoken";
+import { extractWalletFromToken } from "../../src/lib/extract-wallet-from-token";
+
+const SECRET = "test-secret";
+
+function makeToken(overrides: jwt.SignOptions & { sub?: string } = {}) {
+  const { sub = "GABC1234DEFG5678", ...options } = overrides;
+  return jwt.sign({ sub }, SECRET, { expiresIn: "1h", ...options });
+}
+
+describe("extractWalletFromToken", () => {
+  it("returns the sub claim for a valid token", () => {
+    const token = makeToken();
+    expect(extractWalletFromToken(token, SECRET)).toBe("GABC1234DEFG5678");
+  });
+
+  it("returns null for undefined token", () => {
+    expect(extractWalletFromToken(undefined, SECRET)).toBeNull();
+  });
+
+  it("returns null for empty string token", () => {
+    expect(extractWalletFromToken("", SECRET)).toBeNull();
+  });
+
+  it("returns null for expired token", () => {
+    const token = jwt.sign({ sub: "GABC" }, SECRET, { expiresIn: -1 });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null for invalid signature", () => {
+    const token = jwt.sign({ sub: "GABC" }, "wrong-secret");
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null when sub claim is missing", () => {
+    const token = jwt.sign({ foo: "bar" }, SECRET, { expiresIn: "1h" });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null when sub claim is empty string", () => {
+    const token = jwt.sign({ sub: "" }, SECRET, { expiresIn: "1h" });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("never throws", () => {
+    expect(extractWalletFromToken("not.a.jwt", SECRET)).toBeNull();
+    expect(extractWalletFromToken(undefined, "")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #83
Closes #84
Closes #85
Closes #86

## Summary

- **#83**: Added structured info-level log after each successful investment commitment with `investment_id`, `invoice_id`, `investor_wallet` (truncated), `amount_xlm`, `share_percent`, `committed_at`
- **#84**: Added integration test for notification mark-as-read — creates notification, marks read, verifies persistence, unread count decrement, idempotency, and cross-wallet rejection
- **#85**: Added `extractWalletFromToken` helper that safely extracts the `sub` claim from a JWT without throwing — returns null for missing/expired/invalid/malformed tokens
- **#86**: Added `search` query parameter to marketplace invoice listing — case-insensitive match on `customerName`

## Testing

All 260 tests pass including 17 new tests:
- `extract-wallet-from-token.test.ts`: 8 tests
- `invoice-search.integration.test.ts`: 5 tests
- `notification-mark-read.integration.test.ts`: 4 tests