### PR TITLE
feat: webhook signature, settlement guard tests, pool monitor, rate limit tests

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,11 +1,57 @@
 import "dotenv/config";
 import "reflect-metadata";
 import { DataSource } from "typeorm";
+import { logger } from "../observability/logger";
 
 const isProduction = process.env.NODE_ENV === "production";
 const isDevelopment = process.env.NODE_ENV === "development";
 const migrationsPath = isProduction ? "dist/migrations/*.js" : "src/migrations/*.ts";
 const entitiesPath = isProduction ? "dist/models/**/*.js" : "src/models/**/*.ts";
+
+const POOL_MAX = 20;
+const POOL_WARN_THRESHOLD = 0.8; // 80%
+const POOL_LOG_COOLDOWN_MS = 30_000; // 30 seconds
+
+let lastPoolWarnLog = 0;
+let lastPoolErrorLog = 0;
+
+/**
+ * Start monitoring the database connection pool for exhaustion warnings.
+ * Logs a warn when utilisation exceeds 80% and error at 100%.
+ * Each log is emitted at most once per 30 seconds.
+ */
+export function startPoolMonitor(getPool: () => { totalCount: number; idleCount: number; waitingCount: number } | null): void {
+  setInterval(() => {
+    const pool = getPool();
+    if (!pool) return;
+
+    const active = pool.totalCount - pool.idleCount;
+    const utilisation = active / POOL_MAX;
+    const now = Date.now();
+
+    if (utilisation >= 1.0) {
+      if (now - lastPoolErrorLog >= POOL_LOG_COOLDOWN_MS) {
+        lastPoolErrorLog = now;
+        logger.error("Database connection pool exhausted", {
+          active_connections: active,
+          pool_max: POOL_MAX,
+          utilisation_percent: Math.round(utilisation * 100),
+          detected_at: new Date().toISOString(),
+        });
+      }
+    } else if (utilisation >= POOL_WARN_THRESHOLD) {
+      if (now - lastPoolWarnLog >= POOL_LOG_COOLDOWN_MS) {
+        lastPoolWarnLog = now;
+        logger.warn("Database connection pool near capacity", {
+          active_connections: active,
+          pool_max: POOL_MAX,
+          utilisation_percent: Math.round(utilisation * 100),
+          detected_at: new Date().toISOString(),
+        });
+      }
+    }
+  }, 5_000).unref();
+}
 
 const baseConfig = {
   synchronize: isDevelopment,
@@ -28,10 +74,26 @@ export const dataSource = isDevelopment
       type: "postgres",
       url: process.env.DATABASE_URL,
       extra: {
-        max: 20,
+        max: POOL_MAX,
         idleTimeoutMillis: 30000,
         connectionTimeoutMillis: 2000,
       },
     });
+
+// Start pool monitor for production (postgres) connections
+if (!isDevelopment) {
+  startPoolMonitor(() => {
+    try {
+      // TypeORM exposes the underlying pg pool via driver.master/slave
+      const pool = (dataSource.driver as any)?.master;
+      if (pool && typeof pool.totalCount === "number") {
+        return { totalCount: pool.totalCount, idleCount: pool.idleCount, waitingCount: pool.waitingCount };
+      }
+    } catch {
+      // Ignore — pool not yet initialised
+    }
+    return null;
+  });
+}
 
 export default dataSource;

--- a/src/utils/webhook-signature.ts
+++ b/src/utils/webhook-signature.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+
+/**
+ * Compute an HMAC-SHA256 signature for a payload using the given secret.
+ */
+export function computeWebhookSignature(payload: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+/**
+ * Verify that a signature matches the expected HMAC-SHA256 of the payload
+ * computed with the given secret.
+ *
+ * Uses constant-time comparison to prevent timing attacks.
+ *
+ * @returns `true` if the signature is valid, `false` otherwise.
+ * Never throws — safe to use in webhook handlers.
+ */
+export function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
+  try {
+    if (!payload || !signature || !secret) {
+      return false;
+    }
+
+    const expected = computeWebhookSignature(payload, secret);
+
+    // Constant-time comparison
+    if (expected.length !== signature.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}

--- a/tests/integration/settlement.integration.test.ts
+++ b/tests/integration/settlement.integration.test.ts
@@ -106,6 +106,98 @@ function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
   } as Invoice;
 }
 
+describe("Settlement integration: rejecting settlement of non-fully-funded invoices (#88)", () => {
+  it("should reject settlement of a published invoice (no investments)", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource } = createFakeDataSource(invoice);
+
+    const settlementService = new SettlementService(dataSource);
+
+    await expect(
+      settlementService.settleInvoice({
+        invoiceId: invoice.id,
+        proceeds: "6000.0000",
+        actorWallet: "GADMIN",
+      }),
+    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+  });
+
+  it("should reject settlement of a partially funded invoice", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    // Fund only 50%
+    const investorAId = crypto.randomUUID();
+    const investmentA = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorAId,
+      investmentAmount: "3000.0000",
+      investorWallet: "GINVESTORA",
+    });
+
+    // Mark confirmed but invoice is not fully funded
+    const stored = investments.get(investmentA.id)!;
+    stored.status = InvestmentStatus.CONFIRMED;
+    investments.set(investmentA.id, stored);
+
+    // Manually set status to PUBLISHED (not FUNDED) since only partial funding
+    invoice.status = InvoiceStatus.PUBLISHED;
+
+    await expect(
+      settlementService.settleInvoice({
+        invoiceId: invoice.id,
+        proceeds: "6000.0000",
+        actorWallet: "GADMIN",
+      }),
+    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+  });
+
+  it("should succeed when invoice is fully funded", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource, invoices, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    const investorAId = crypto.randomUUID();
+    const investorBId = crypto.randomUUID();
+
+    const investmentA = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorAId,
+      investmentAmount: "4000.0000",
+      investorWallet: "GINVESTORA",
+    });
+
+    const investmentB = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorBId,
+      investmentAmount: "2000.0000",
+      investorWallet: "GINVESTORB",
+    });
+
+    for (const investment of [investmentA, investmentB]) {
+      const stored = investments.get(investment.id)!;
+      stored.status = InvestmentStatus.CONFIRMED;
+      investments.set(investment.id, stored);
+    }
+
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.FUNDED);
+
+    const result = await settlementService.settleInvoice({
+      invoiceId: invoice.id,
+      proceeds: "6600.0000",
+      actorWallet: "GADMIN",
+    });
+
+    expect(result.status).toBe(InvoiceStatus.SETTLED);
+    expect(result.settlements).toHaveLength(2);
+  });
+});
+
 describe("Settlement integration: funding multiple investors then settling", () => {
   it("distributes proceeds pro-rata to each investor and marks the invoice settled", async () => {
     const invoice = createInvoice();

--- a/tests/rate-limit-wallet.test.ts
+++ b/tests/rate-limit-wallet.test.ts
@@ -231,4 +231,95 @@ describe("Wallet-based rate limiting", () => {
             .post("/api/v1/test-rate-limit")
             .expect(401);
     });
+
+    it("should reset counter after window expires and allow full quota again", async () => {
+        resetRateLimitStores();
+
+        const shortApp = express();
+        shortApp.use(express.json());
+
+        const limiter = createWalletRateLimiter(
+            { windowMs: 150, maxRequests: 3 },
+            "reset-test",
+        );
+
+        shortApp.post("/test", (req, res, next) => {
+            const authHeader = req.headers.authorization;
+            if (!authHeader?.startsWith("Bearer ")) { res.status(401).json({ error: "Unauthorized" }); return; }
+            const token = authHeader.slice(7);
+            try {
+                const payload = jwt.verify(token, TEST_SECRET) as any;
+                (req as any).user = { id: payload.sub, stellarAddress: payload.stellarAddress };
+                next();
+            } catch { res.status(401).json({ error: "Invalid token" }); }
+        }, limiter, (_req, res) => { res.status(200).json({ success: true }); });
+
+        shortApp.use(createErrorMiddleware(logger));
+
+        const token = createToken(WALLET_A);
+
+        // Exhaust the limit (3 requests)
+        for (let i = 0; i < 3; i++) {
+            await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(200);
+        }
+
+        // 4th request should be rate limited
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(429);
+
+        // Wait for window to expire
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Counter should have reset — 3 more requests should succeed
+        for (let i = 0; i < 3; i++) {
+            await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(200);
+        }
+
+        // 4th request after reset should be rate limited again
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(429);
+    });
+
+    it("should reset per wallet, not globally", async () => {
+        resetRateLimitStores();
+
+        const shortApp = express();
+        shortApp.use(express.json());
+
+        const limiter = createWalletRateLimiter(
+            { windowMs: 150, maxRequests: 2 },
+            "per-wallet-test",
+        );
+
+        shortApp.post("/test", (req, res, next) => {
+            const authHeader = req.headers.authorization;
+            if (!authHeader?.startsWith("Bearer ")) { res.status(401).json({ error: "Unauthorized" }); return; }
+            const token = authHeader.slice(7);
+            try {
+                const payload = jwt.verify(token, TEST_SECRET) as any;
+                (req as any).user = { id: payload.sub, stellarAddress: payload.stellarAddress };
+                next();
+            } catch { res.status(401).json({ error: "Invalid token" }); }
+        }, limiter, (_req, res) => { res.status(200).json({ success: true }); });
+
+        shortApp.use(createErrorMiddleware(logger));
+
+        const tokenA = createToken(WALLET_A);
+        const tokenB = createToken(WALLET_B);
+
+        // Exhaust wallet A
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(429);
+
+        // Wallet B should still have full quota
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(429);
+
+        // Wait for window to expire
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Both wallets should have fresh quotas
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+    });
 });

--- a/tests/unit/webhook-signature.test.ts
+++ b/tests/unit/webhook-signature.test.ts
@@ -1,0 +1,61 @@
+import {
+  computeWebhookSignature,
+  verifyWebhookSignature,
+} from "../../src/utils/webhook-signature";
+
+describe("verifyWebhookSignature", () => {
+  const SECRET_A = "whsec_test_secret_a_12345";
+  const SECRET_B = "whsec_test_secret_b_67890";
+  const PAYLOAD = '{"event":"invoice.paid","amount":6000}';
+
+  it("should return true for correct payload + correct secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(verifyWebhookSignature(PAYLOAD, signature, SECRET_A)).toBe(true);
+  });
+
+  it("should return false for correct payload + wrong secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(verifyWebhookSignature(PAYLOAD, signature, SECRET_B)).toBe(false);
+  });
+
+  it("should return false for wrong payload + correct secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const tamperedPayload = '{"event":"invoice.paid","amount":9999}';
+    expect(verifyWebhookSignature(tamperedPayload, signature, SECRET_A)).toBe(false);
+  });
+
+  it("should return false for a completely fabricated signature", () => {
+    expect(verifyWebhookSignature(PAYLOAD, "not-a-real-signature", SECRET_A)).toBe(false);
+  });
+
+  it("should return false for empty inputs", () => {
+    expect(verifyWebhookSignature("", computeWebhookSignature(PAYLOAD, SECRET_A), SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, "", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, computeWebhookSignature(PAYLOAD, SECRET_A), "")).toBe(false);
+  });
+
+  it("should never throw an exception", () => {
+    // Various malformed inputs should all return false, never throw
+    expect(verifyWebhookSignature(PAYLOAD, "zzz", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, "abc123", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature("{}", "0000000000000000", SECRET_A)).toBe(false);
+  });
+
+  it("should return false when signature length differs from expected", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    // Truncate the signature
+    expect(verifyWebhookSignature(PAYLOAD, signature.slice(0, 10), SECRET_A)).toBe(false);
+  });
+
+  it("should produce deterministic signatures", () => {
+    const sig1 = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const sig2 = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(sig1).toBe(sig2);
+  });
+
+  it("should produce different signatures for different secrets", () => {
+    const sigA = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const sigB = computeWebhookSignature(PAYLOAD, SECRET_B);
+    expect(sigA).not.toBe(sigB);
+  });
+});


### PR DESCRIPTION
Fixes #87, Fixes #88, Fixes #89, Fixes #90

## What changed

**#87 — webhook signature verification**
- Created `src/utils/webhook-signature.ts` with `computeWebhookSignature` and `verifyWebhookSignature`
- Uses `crypto.timingSafeEqual` for constant-time comparison
- Created `tests/unit/webhook-signature.test.ts` with 8 tests covering wrong secret, wrong payload, empty inputs, length mismatch

**#88 — settlement rejection tests**
- Added 3 tests to `tests/integration/settlement.integration.test.ts`:
  - Published invoice (no investments) → rejects with INVALID_INVOICE_STATUS
  - Partially funded invoice → rejects with INVALID_INVOICE_STATUS
  - Fully funded invoice → succeeds

**#89 — DB pool exhaustion logging**
- Added `startPoolMonitor()` to `src/config/database.ts`
- Warns at 80% utilisation, errors at 100%
- Logs at most once per 30 seconds with fields: active_connections, pool_max, utilisation_percent, detected_at

**#90 — rate limiter window reset tests**
- Added test: counter resets after window expires, full quota available again
- Added test: window reset applies per wallet, not globally

## How to test
`npm test` — all new tests are in `tests/unit/` and `tests/integration/`