### PR TITLE
feat: expand investor dashboard metrics

### DIFF
--- a/src/services/investment.service.ts
+++ b/src/services/investment.service.ts
@@ -24,9 +24,16 @@ export interface InvestorDashboard {
   totalInvested: string;
   totalReturns: string;
   activeInvestments: number;
+  activeCount: number;
+  activeTotal: string;
+  settledCount: number;
+  settledReturns: string;
+  failedCount: number;
 }
 
 const ACTIVE_INVESTMENT_STATUSES = [InvestmentStatus.PENDING, InvestmentStatus.CONFIRMED];
+const SETTLED_INVESTMENT_STATUSES = [InvestmentStatus.SETTLED];
+const FAILED_INVESTMENT_STATUSES = [InvestmentStatus.CANCELLED];
 
 export class InvestmentService {
   constructor(private readonly dataSource: DataSource) {}
@@ -47,24 +54,41 @@ export class InvestmentService {
 
     let totalInvested = new Decimal(0);
     let totalReturns = new Decimal(0);
-    let activeInvestments = 0;
+    let activeCount = 0;
+    let activeTotal = new Decimal(0);
+    let settledCount = 0;
+    let failedCount = 0;
 
     for (const investment of investments) {
-      totalInvested = totalInvested.plus(new Decimal(investment.investmentAmount));
-
-      if (investment.status === InvestmentStatus.SETTLED && investment.actualReturn !== null) {
-        totalReturns = totalReturns.plus(new Decimal(investment.actualReturn));
-      }
+     const amount = new Decimal(investment.investmentAmount);
+     totalInvested = totalInvested.plus(amount);
 
       if (ACTIVE_INVESTMENT_STATUSES.includes(investment.status)) {
-        activeInvestments += 1;
-      }
+       activeCount += 1;
+       activeTotal = activeTotal.plus(amount);
+     }
+
+     if (SETTLED_INVESTMENT_STATUSES.includes(investment.status)) {
+       settledCount += 1;
+       if (investment.actualReturn !== null) {
+         totalReturns = totalReturns.plus(new Decimal(investment.actualReturn));
+       }
+     }
+
+     if (FAILED_INVESTMENT_STATUSES.includes(investment.status)) {
+       failedCount += 1;
+     }
     }
 
     return {
-      totalInvested: totalInvested.toFixed(4),
-      totalReturns: totalReturns.toFixed(4),
-      activeInvestments,
+     totalInvested: totalInvested.toFixed(4),
+     totalReturns: totalReturns.toFixed(4),
+     activeInvestments: activeCount,
+     activeCount,
+     activeTotal: activeTotal.toFixed(4),
+     settledCount,
+     settledReturns: totalReturns.toFixed(4),
+     failedCount,
     };
   }
 

--- a/tests/integration/investor-dashboard.test.ts
+++ b/tests/integration/investor-dashboard.test.ts
@@ -9,6 +9,7 @@ describe("Investor dashboard aggregate", () => {
   let investmentService: InvestmentService;
 
   const walletAId = "wallet-a";
+  const walletBId = "wallet-b";
 
   function seedInvestment(overrides: Partial<Investment>): Investment {
     return {
@@ -40,33 +41,65 @@ describe("Investor dashboard aggregate", () => {
     investmentService = new InvestmentService(mockDataSource);
   });
 
-  it("aggregates total invested, total returns, and active count across investment states", async () => {
-    // Wallet A: two active investments (2000, 3000) and one settled
-    // investment (1000, realised return 1100).
-    mockRepository.find.mockResolvedValue([
-      seedInvestment({ id: "inv-1", investmentAmount: "2000.0000", status: InvestmentStatus.PENDING }),
-      seedInvestment({ id: "inv-2", investmentAmount: "3000.0000", status: InvestmentStatus.CONFIRMED }),
+  it("aggregates active, settled, and failed positions without leaking other investors", async () => {
+    const investments = [
+      seedInvestment({ id: "inv-1", investorId: walletAId, investmentAmount: "3000.0000", status: InvestmentStatus.PENDING }),
+      seedInvestment({ id: "inv-2", investorId: walletAId, investmentAmount: "2000.0000", status: InvestmentStatus.CONFIRMED }),
       seedInvestment({
         id: "inv-3",
-        investmentAmount: "1000.0000",
+        investorId: walletAId,
+        investmentAmount: "1500.0000",
         status: InvestmentStatus.SETTLED,
-        actualReturn: "1100.0000",
+        actualReturn: "1650.0000",
       }),
-    ]);
+      seedInvestment({
+        id: "inv-4",
+        investorId: walletAId,
+        investmentAmount: "500.0000",
+        status: InvestmentStatus.CANCELLED,
+      }),
+      seedInvestment({
+        id: "inv-5",
+        investorId: walletBId,
+        investmentAmount: "9999.0000",
+        status: InvestmentStatus.PENDING,
+      }),
+    ];
+
+    mockRepository.find.mockImplementation(async (options) => {
+      const investorId =
+        options?.where && !Array.isArray(options.where)
+          ? (options.where as { investorId?: string }).investorId
+          : undefined;
+
+      return investments.filter((investment) => investment.investorId === investorId);
+    });
 
     const dashboard = await investmentService.getInvestorDashboard(walletAId);
 
     expect(mockDataSource.getRepository).toHaveBeenCalledWith(Investment);
     expect(mockRepository.find).toHaveBeenCalledWith({ where: { investorId: walletAId } });
 
-    expect(dashboard.totalInvested).toBe("6000.0000");
-    expect(dashboard.totalReturns).toBe("1100.0000");
-    expect(dashboard.activeInvestments).toBe(2);
+    expect(dashboard).toMatchObject({
+      totalInvested: "7000.0000",
+      totalReturns: "1650.0000",
+      activeInvestments: 2,
+      activeCount: 2,
+      activeTotal: "5000.0000",
+      settledCount: 1,
+      settledReturns: "1650.0000",
+      failedCount: 1,
+    });
   });
 
   it("does not count pending returns towards totalReturns", async () => {
     mockRepository.find.mockResolvedValue([
-      seedInvestment({ id: "inv-1", investmentAmount: "500.0000", status: InvestmentStatus.PENDING, expectedReturn: "550.0000" }),
+      seedInvestment({
+        id: "inv-1",
+        investmentAmount: "500.0000",
+        status: InvestmentStatus.PENDING,
+        expectedReturn: "550.0000",
+      }),
     ]);
 
     const dashboard = await investmentService.getInvestorDashboard(walletAId);
@@ -74,6 +107,10 @@ describe("Investor dashboard aggregate", () => {
     expect(dashboard.totalInvested).toBe("500.0000");
     expect(dashboard.totalReturns).toBe("0.0000");
     expect(dashboard.activeInvestments).toBe(1);
+    expect(dashboard.activeCount).toBe(1);
+    expect(dashboard.activeTotal).toBe("500.0000");
+    expect(dashboard.settledCount).toBe(0);
+    expect(dashboard.failedCount).toBe(0);
   });
 
   it("excludes cancelled investments from the active count", async () => {
@@ -85,6 +122,10 @@ describe("Investor dashboard aggregate", () => {
 
     expect(dashboard.totalInvested).toBe("800.0000");
     expect(dashboard.activeInvestments).toBe(0);
+    expect(dashboard.activeCount).toBe(0);
+    expect(dashboard.activeTotal).toBe("0.0000");
+    expect(dashboard.settledCount).toBe(0);
+    expect(dashboard.failedCount).toBe(1);
   });
 
   it("returns zero for all fields when the wallet has no investments", async () => {
@@ -96,6 +137,11 @@ describe("Investor dashboard aggregate", () => {
       totalInvested: "0.0000",
       totalReturns: "0.0000",
       activeInvestments: 0,
+      activeCount: 0,
+      activeTotal: "0.0000",
+      settledCount: 0,
+      settledReturns: "0.0000",
+      failedCount: 0,
     });
   });
 });


### PR DESCRIPTION
Expands the investor dashboard aggregation to report active, settled, and failed positions without leaking other investors' data.

Closes #81
