### PR TITLE
fix(auth,invoices): add structured auth-failure logging and invoice publish minimum threshold

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2137,6 +2138,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2279,6 +2281,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2467,6 +2470,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3104,6 +3108,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3736,6 +3741,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4120,29 +4126,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -4259,6 +4242,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4560,6 +4544,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5925,6 +5910,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7883,6 +7869,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9587,6 +9574,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9897,6 +9885,7 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,12 +14,14 @@ import { createNotificationRouter } from "./routes/notification.routes";
 import { createInvoiceRouter } from "./routes/invoice.routes";
 import { createInvestmentRouter } from "./routes/investment.routes";
 import { createSettlementRouter } from "./routes/settlement.routes";
+import { createMarketplaceRouter } from "./routes/marketplace.routes";
 
 import type { AuthService } from "./services/auth.service";
 import type { NotificationService } from "./services/notification.service";
 import type { InvoiceService } from "./services/invoice.service";
 import type { InvestmentService } from "./services/investment.service";
 import type { SettlementService } from "./services/settlement.service";
+import type { MarketplaceService } from "./services/marketplace.service";
 
 import dataSource from "./config/database";
 
@@ -55,6 +57,7 @@ export interface AppDependencies {
   invoiceService?: InvoiceService;
   investmentService?: InvestmentService;
   settlementService?: SettlementService;
+  marketplaceService?: MarketplaceService;
   logger?: AppLogger;
   metricsEnabled?: boolean;
   metricsRegistry?: MetricsRegistry;
@@ -79,6 +82,7 @@ export function createApp({
   invoiceService,
   investmentService,
   settlementService,
+  marketplaceService,
   logger: appLogger = logger,
   metricsEnabled = true,
   metricsRegistry = new MetricsRegistry(),
@@ -179,6 +183,10 @@ export function createApp({
 
   if (settlementService) {
     app.use("/api/v1/settlements", createSettlementRouter({ settlementService }));
+  }
+
+  if (marketplaceService) {
+    app.use("/api/v1/marketplace", createMarketplaceRouter({ marketplaceService }));
   }
 
   app.use(notFoundMiddleware);

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -1,11 +1,57 @@
 import "dotenv/config";
 import "reflect-metadata";
 import { DataSource } from "typeorm";
+import { logger } from "../observability/logger";
 
 const isProduction = process.env.NODE_ENV === "production";
 const isDevelopment = process.env.NODE_ENV === "development";
 const migrationsPath = isProduction ? "dist/migrations/*.js" : "src/migrations/*.ts";
 const entitiesPath = isProduction ? "dist/models/**/*.js" : "src/models/**/*.ts";
+
+const POOL_MAX = 20;
+const POOL_WARN_THRESHOLD = 0.8; // 80%
+const POOL_LOG_COOLDOWN_MS = 30_000; // 30 seconds
+
+let lastPoolWarnLog = 0;
+let lastPoolErrorLog = 0;
+
+/**
+ * Start monitoring the database connection pool for exhaustion warnings.
+ * Logs a warn when utilisation exceeds 80% and error at 100%.
+ * Each log is emitted at most once per 30 seconds.
+ */
+export function startPoolMonitor(getPool: () => { totalCount: number; idleCount: number; waitingCount: number } | null): void {
+  setInterval(() => {
+    const pool = getPool();
+    if (!pool) return;
+
+    const active = pool.totalCount - pool.idleCount;
+    const utilisation = active / POOL_MAX;
+    const now = Date.now();
+
+    if (utilisation >= 1.0) {
+      if (now - lastPoolErrorLog >= POOL_LOG_COOLDOWN_MS) {
+        lastPoolErrorLog = now;
+        logger.error("Database connection pool exhausted", {
+          active_connections: active,
+          pool_max: POOL_MAX,
+          utilisation_percent: Math.round(utilisation * 100),
+          detected_at: new Date().toISOString(),
+        });
+      }
+    } else if (utilisation >= POOL_WARN_THRESHOLD) {
+      if (now - lastPoolWarnLog >= POOL_LOG_COOLDOWN_MS) {
+        lastPoolWarnLog = now;
+        logger.warn("Database connection pool near capacity", {
+          active_connections: active,
+          pool_max: POOL_MAX,
+          utilisation_percent: Math.round(utilisation * 100),
+          detected_at: new Date().toISOString(),
+        });
+      }
+    }
+  }, 5_000).unref();
+}
 
 const baseConfig = {
   synchronize: isDevelopment,
@@ -28,10 +74,26 @@ export const dataSource = isDevelopment
       type: "postgres",
       url: process.env.DATABASE_URL,
       extra: {
-        max: 20,
+        max: POOL_MAX,
         idleTimeoutMillis: 30000,
         connectionTimeoutMillis: 2000,
       },
     });
+
+// Start pool monitor for production (postgres) connections
+if (!isDevelopment) {
+  startPoolMonitor(() => {
+    try {
+      // TypeORM exposes the underlying pg pool via driver.master/slave
+      const pool = (dataSource.driver as any)?.master;
+      if (pool && typeof pool.totalCount === "number") {
+        return { totalCount: pool.totalCount, idleCount: pool.idleCount, waitingCount: pool.waitingCount };
+      }
+    } catch {
+      // Ignore — pool not yet initialised
+    }
+    return null;
+  });
+}
 
 export default dataSource;

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -85,7 +85,7 @@ if (!isDevelopment) {
   startPoolMonitor(() => {
     try {
       // TypeORM exposes the underlying pg pool via driver.master/slave
-      const pool = (dataSource.driver as any)?.master;
+      const pool = (dataSource.driver as unknown as { master?: { totalCount: number; idleCount: number; waitingCount: number } })?.master;
       if (pool && typeof pool.totalCount === "number") {
         return { totalCount: pool.totalCount, idleCount: pool.idleCount, waitingCount: pool.waitingCount };
       }

--- a/src/controllers/investment.controller.ts
+++ b/src/controllers/investment.controller.ts
@@ -31,6 +31,7 @@ export class InvestmentController {
         invoiceId,
         investorId: user.id,
         investmentAmount,
+        investorWallet: user.stellarAddress,
       });
 
       return res.status(201).json({

--- a/src/controllers/marketplace.controller.ts
+++ b/src/controllers/marketplace.controller.ts
@@ -17,6 +17,7 @@ const getInvoicesSchema = Joi.object({
   maxAmount: Joi.number().min(0).optional(),
   sort: Joi.string().valid("due_date", "discount_rate", "amount", "created_at").default("due_date"),
   sortOrder: Joi.string().valid("ASC", "DESC").default("ASC"),
+  search: Joi.string().trim().max(255).optional(),
 });
 
 export interface GetInvoicesRequest extends Request {
@@ -58,6 +59,7 @@ export function createMarketplaceController(marketplaceService: MarketplaceServi
           maxAmount: value.maxAmount,
           sort: value.sort,
           sortOrder: value.sortOrder,
+          search: value.search,
         };
 
         // Validate amount range

--- a/src/controllers/settlement.controller.ts
+++ b/src/controllers/settlement.controller.ts
@@ -1,11 +1,16 @@
-import { Request, Response } from "express";
+import { Response } from "express";
 import { SettlementService } from "../services/settlement.service";
+import { AuthenticatedRequest } from "../types/auth";
 
 export class SettlementController {
   constructor(private readonly settlementService: SettlementService) {}
 
-  settleInvoice = async (req: Request, res: Response) => {
+  settleInvoice = async (req: AuthenticatedRequest, res: Response) => {
     try {
+      if (!req.user) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
       const invoiceId = req.params.invoiceId as string;
       const { proceeds } = req.body;
 
@@ -21,6 +26,7 @@ export class SettlementController {
       const result = await this.settlementService.settleInvoice({
         invoiceId,
         proceeds,
+        actorWallet: req.user.stellarAddress,
       });
 
       return res.status(200).json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { createInvoiceService } from "./services/invoice.service";
 import { createIPFSService } from "./services/ipfs.service";
 import { createInvestmentService } from "./services/investment.service";
 import { createSettlementService } from "./services/settlement.service";
+import { createMarketplaceService } from "./services/marketplace.service";
 
 export async function bootstrap(): Promise<{ server: Server }> {
   const config = getConfig();
@@ -26,6 +27,7 @@ export async function bootstrap(): Promise<{ server: Server }> {
   const invoiceService = createInvoiceService(dataSource, ipfsService);
   const investmentService = createInvestmentService(dataSource);
   const settlementService = createSettlementService(dataSource);
+  const marketplaceService = createMarketplaceService(dataSource);
 
   const app = createApp({
     authService,
@@ -33,6 +35,7 @@ export async function bootstrap(): Promise<{ server: Server }> {
     invoiceService,
     investmentService,
     settlementService,
+    marketplaceService,
     config,
     logger,
     metricsEnabled: config.observability.metricsEnabled,

--- a/src/lib/auth-failure.ts
+++ b/src/lib/auth-failure.ts
@@ -1,0 +1,69 @@
+import jwt from "jsonwebtoken";
+
+export type AuthFailureReason =
+  | "missing_token"
+  | "expired_token"
+  | "invalid_signature"
+  | "invalid_token"
+  | "unparseable_token";
+
+export interface AuthFailureDetails {
+  reason: AuthFailureReason;
+  truncatedAddress: string | null;
+  failedAt: string;
+}
+
+export function truncateWalletAddress(
+  address: string | null | undefined,
+): string | null {
+  if (!address) {
+    return null;
+  }
+
+  if (address.length <= 8) {
+    return address;
+  }
+
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+export function extractWalletFromUnverifiedToken(token?: string): string | null {
+  if (!token) {
+    return null;
+  }
+
+  const decoded = jwt.decode(token);
+  if (!decoded || typeof decoded === "string") {
+    return null;
+  }
+
+  const sub = decoded.sub;
+  return typeof sub === "string" && sub.length > 0 ? sub : null;
+}
+
+export function buildAuthFailureDetails(
+  token: string | undefined,
+  reason: AuthFailureReason,
+): { authFailure: AuthFailureDetails } {
+  return {
+    authFailure: {
+      reason,
+      truncatedAddress: truncateWalletAddress(
+        extractWalletFromUnverifiedToken(token),
+      ),
+      failedAt: new Date().toISOString(),
+    },
+  };
+}
+
+export function classifyJwtError(error: unknown): AuthFailureReason {
+  if (error instanceof jwt.TokenExpiredError) {
+    return "expired_token";
+  }
+
+  if (error instanceof jwt.JsonWebTokenError) {
+    return "invalid_signature";
+  }
+
+  return "invalid_token";
+}

--- a/src/lib/decimal-bigint.ts
+++ b/src/lib/decimal-bigint.ts
@@ -1,0 +1,29 @@
+const SCALE = 4;
+const SCALE_FACTOR = 10n ** BigInt(SCALE);
+
+/**
+ * Converts a fixed-4-decimal-place amount string (e.g. "1234.5600") into a
+ * scaled bigint (12345600n) suitable for pure integer arithmetic.
+ */
+export function decimalStringToScaledBigInt(value: string): bigint {
+  const normalized = value.trim();
+  const isNegative = normalized.startsWith("-");
+  const unsigned = isNegative ? normalized.slice(1) : normalized;
+  const [wholePart, fractionalPart = ""] = unsigned.split(".");
+  const paddedFraction = `${fractionalPart}${"0".repeat(SCALE)}`.slice(0, SCALE);
+  const scaled = BigInt(`${wholePart || "0"}${paddedFraction}`);
+
+  return isNegative ? -scaled : scaled;
+}
+
+/**
+ * Converts a scaled bigint back into a fixed-4-decimal-place amount string.
+ */
+export function scaledBigIntToDecimalString(value: bigint): string {
+  const isNegative = value < 0n;
+  const absolute = isNegative ? -value : value;
+  const whole = absolute / SCALE_FACTOR;
+  const fraction = (absolute % SCALE_FACTOR).toString().padStart(SCALE, "0");
+
+  return `${isNegative ? "-" : ""}${whole}.${fraction}`;
+}

--- a/src/lib/extract-wallet-from-token.ts
+++ b/src/lib/extract-wallet-from-token.ts
@@ -1,0 +1,29 @@
+import jwt from "jsonwebtoken";
+
+/**
+ * Safely extracts the wallet address (sub claim) from a JWT token.
+ *
+ * Returns the `sub` claim string on a valid, unexpired token.
+ * Returns null for: missing token, expired token, invalid signature,
+ * missing `sub` claim. Never throws.
+ */
+export function extractWalletFromToken(
+  token: string | undefined,
+  secret: string,
+): string | null {
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as jwt.JwtPayload;
+
+    if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+      return null;
+    }
+
+    return payload.sub;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/investor-return.ts
+++ b/src/lib/investor-return.ts
@@ -1,0 +1,23 @@
+/**
+ * Computes an investor's pro-rata share of settled proceeds using pure
+ * integer arithmetic. Division truncates toward zero, which for
+ * non-negative bigint operands is equivalent to flooring — the investor
+ * never receives more than their exact proportional share.
+ */
+export function computeInvestorReturn(
+  investedAmount: bigint,
+  totalFunded: bigint,
+  settledProceeds: bigint,
+): bigint {
+  if (totalFunded <= 0n) {
+    throw new RangeError("totalFunded must be greater than zero");
+  }
+  if (investedAmount < 0n) {
+    throw new RangeError("investedAmount must not be negative");
+  }
+  if (settledProceeds < 0n) {
+    throw new RangeError("settledProceeds must not be negative");
+  }
+
+  return (investedAmount * settledProceeds) / totalFunded;
+}

--- a/src/lib/invoice-lifecycle-log.ts
+++ b/src/lib/invoice-lifecycle-log.ts
@@ -1,0 +1,28 @@
+import type { AppLogger } from "../observability/logger";
+import { truncateWalletAddress } from "./kyc";
+import type { InvoiceStatus } from "../types/enums";
+
+export type InvoiceTransitionReason = "seller_published" | "fully_funded" | "admin_settled";
+
+export interface InvoiceTransitionLogInput {
+  invoiceId: string;
+  fromState: InvoiceStatus;
+  toState: InvoiceStatus;
+  actorWallet: string;
+  reason: InvoiceTransitionReason;
+}
+
+/**
+ * Emits the invoice lifecycle audit log. Callers must invoke this only
+ * after the state-change database write has succeeded.
+ */
+export function logInvoiceTransition(logger: AppLogger, input: InvoiceTransitionLogInput): void {
+  logger.info("Invoice lifecycle state transition.", {
+    invoice_id: input.invoiceId,
+    from_state: input.fromState,
+    to_state: input.toState,
+    actor_wallet: truncateWalletAddress(input.actorWallet),
+    reason: input.reason,
+    transitioned_at: new Date().toISOString(),
+  });
+}

--- a/src/lib/validate-invoice-for-publish.ts
+++ b/src/lib/validate-invoice-for-publish.ts
@@ -1,4 +1,5 @@
-import type { Invoice } from "@/models/Invoice.model";
+import { Decimal } from "decimal.js";
+import type { Invoice } from "../models/Invoice.model";
 
 export interface ValidationError {
   field: string;
@@ -7,6 +8,7 @@ export interface ValidationError {
 }
 
 const MIN_LEAD_TIME_MS = 24 * 60 * 60 * 1000;
+export const MIN_FACE_VALUE_XLM = new Decimal("100");
 
 /**
  * Validates that an invoice meets the minimum field requirements
@@ -15,12 +17,12 @@ const MIN_LEAD_TIME_MS = 24 * 60 * 60 * 1000;
 export function validateInvoiceForPublish(invoice: Invoice): ValidationError[] {
   const errors: ValidationError[] = [];
 
-  const faceValue = parseFloat(invoice.amount);
-  if (!(faceValue > 0)) {
+  const faceValue = new Decimal(invoice.amount);
+  if (faceValue.lessThan(MIN_FACE_VALUE_XLM)) {
     errors.push({
       field: "amount",
-      code: "FACE_VALUE_NOT_POSITIVE",
-      message: "Invoice face value must be greater than zero.",
+      code: "FACE_VALUE_TOO_LOW",
+      message: `Invoice face value must be at least ${MIN_FACE_VALUE_XLM.toFixed(4)} XLM.`,
     });
   }
 

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -6,6 +6,10 @@ import type { AuthenticatedRequest } from "../types/auth";
 
 import { HttpError } from "../utils/http-error";
 import { UserType, KYCStatus } from "../types/enums";
+import {
+  buildAuthFailureDetails,
+  classifyJwtError,
+} from "../lib/auth-failure";
 
 interface AuthTokenPayload {
   sub: string;
@@ -21,7 +25,13 @@ export function createAuthMiddleware(authService: AuthService) {
     const authHeader = req.headers.authorization;
 
     if (!authHeader?.startsWith("Bearer ")) {
-      next(new HttpError(401, "Authorization token is required."));
+      next(
+        new HttpError(
+          401,
+          "Authorization token is required.",
+          buildAuthFailureDetails(undefined, "missing_token"),
+        ),
+      );
       return;
     }
 
@@ -30,8 +40,19 @@ export function createAuthMiddleware(authService: AuthService) {
     try {
       req.user = await authService.getCurrentUser(token);
       next();
-    } catch {
-      next(new HttpError(401, "Invalid or expired token."));
+    } catch (error) {
+      if (error instanceof HttpError) {
+        next(error);
+        return;
+      }
+
+      next(
+        new HttpError(
+          401,
+          "Invalid or expired token.",
+          buildAuthFailureDetails(token, classifyJwtError(error)),
+        ),
+      );
     }
   };
 }
@@ -44,7 +65,13 @@ export function authenticateJWT(
   const authHeader = req.headers.authorization;
 
   if (!authHeader?.startsWith("Bearer ")) {
-    next(new HttpError(401, "Authorization token is required."));
+    next(
+      new HttpError(
+        401,
+        "Authorization token is required.",
+        buildAuthFailureDetails(undefined, "missing_token"),
+      ),
+    );
     return;
   }
 
@@ -67,8 +94,14 @@ export function authenticateJWT(
     };
 
     next();
-  } catch {
-    next(new HttpError(401, "Invalid or expired token."));
+  } catch (error) {
+    next(
+      new HttpError(
+        401,
+        "Invalid or expired token.",
+        buildAuthFailureDetails(token, classifyJwtError(error)),
+      ),
+    );
   }
 }
 

--- a/src/middleware/error.middleware.ts
+++ b/src/middleware/error.middleware.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 import type { AppLogger } from "../observability/logger";
 
 import { AppError, HttpError } from "../utils/http-error";
+import type { AuthFailureDetails } from "../lib/auth-failure";
 
 export function notFoundMiddleware(
   _req: Request,
@@ -20,19 +21,34 @@ export function createErrorMiddleware(logger: AppLogger) {
   ): void => {
 
     if (error instanceof AppError || error instanceof HttpError) {
-      logger.warn("HTTP request failed.", {
-        method: req.method,
-        path: req.path,
-        statusCode: error.statusCode,
-        error: error.message,
-      });
-
       res.status(error.statusCode).json({
         success: false,
         error: {
           code: error.code,
           message: error.message,
         },
+      });
+
+      const authFailure = (error.details as { authFailure?: AuthFailureDetails } | undefined)
+        ?.authFailure;
+
+      if (error.statusCode === 401 && authFailure) {
+        logger.warn("API authentication failure.", {
+          method: req.method,
+          path: req.path,
+          reason: authFailure.reason,
+          truncated_address: authFailure.truncatedAddress,
+          failed_at: authFailure.failedAt,
+          statusCode: error.statusCode,
+        });
+        return;
+      }
+
+      logger.warn("HTTP request failed.", {
+        method: req.method,
+        path: req.path,
+        statusCode: error.statusCode,
+        error: error.message,
       });
 
       return;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -7,6 +7,10 @@ import { AuthChallenge } from "../models/AuthChallenge.model";
 import { User } from "../models/User.model";
 import type { PublicUser } from "../types/auth";
 import { HttpError } from "../utils/http-error";
+import {
+  buildAuthFailureDetails,
+  classifyJwtError,
+} from "../lib/auth-failure";
 
 interface ChallengeRecord {
   id: string;
@@ -178,12 +182,20 @@ export class AuthService {
 
     try {
       payload = jwt.verify(token, this.config.jwt.secret) as AuthTokenPayload;
-    } catch {
-      throw new HttpError(401, "Invalid or expired token.");
+    } catch (error) {
+      throw new HttpError(
+        401,
+        "Invalid or expired token.",
+        buildAuthFailureDetails(token, classifyJwtError(error)),
+      );
     }
 
     if (!payload.sub) {
-      throw new HttpError(401, "Invalid token payload.");
+      throw new HttpError(
+        401,
+        "Invalid token payload.",
+        buildAuthFailureDetails(token, "invalid_token"),
+      );
     }
 
     const user = await this.userRepository.findByStellarAddress(payload.sub);

--- a/src/services/investment.service.ts
+++ b/src/services/investment.service.ts
@@ -4,6 +4,8 @@ import { Investment } from "../models/Investment.model";
 import { InvoiceStatus, InvestmentStatus } from "../types/enums";
 import { ServiceError } from "../utils/service-error";
 import { Decimal } from "decimal.js";
+import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
+import { logger } from "../observability/logger";
 
 // Formula for expected return:
 // Investor's share of the invoice face value (amount) proportional to their contribution to the fundable amount (netAmount).
@@ -14,6 +16,7 @@ export interface CreateInvestmentInput {
   invoiceId: string;
   investorId: string;
   investmentAmount: string;
+  investorWallet: string;
 }
 
 export interface InvestorDashboard {
@@ -69,7 +72,7 @@ export class InvestmentService {
    * Uses a database transaction with a row-level lock on the invoice to prevent over-subscription.
    */
   async createInvestment(input: CreateInvestmentInput): Promise<Investment> {
-    const { invoiceId, investorId, investmentAmount } = input;
+    const { invoiceId, investorId, investmentAmount, investorWallet } = input;
 
     // Validate investment amount
     const amount = new Decimal(investmentAmount);
@@ -145,8 +148,17 @@ export class InvestmentService {
       // 7. Transition invoice to FUNDED if fully subscribed
       const newTotalInvested = totalInvested.plus(amount);
       if (newTotalInvested.gte(netAmount)) {
+        const previousStatus = invoice.status;
         invoice.status = InvoiceStatus.FUNDED;
         await transactionalEntityManager.save(Invoice, invoice);
+
+        logInvoiceTransition(logger, {
+          invoiceId: invoice.id,
+          fromState: previousStatus,
+          toState: InvoiceStatus.FUNDED,
+          actorWallet: investorWallet,
+          reason: "fully_funded",
+        });
       }
 
       return savedInvestment;

--- a/src/services/investment.service.ts
+++ b/src/services/investment.service.ts
@@ -6,6 +6,7 @@ import { ServiceError } from "../utils/service-error";
 import { Decimal } from "decimal.js";
 import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
 import { logger } from "../observability/logger";
+import { stroopsToXlm } from "../lib/stellar-format";
 
 // Formula for expected return:
 // Investor's share of the invoice face value (amount) proportional to their contribution to the fundable amount (netAmount).
@@ -145,7 +146,23 @@ export class InvestmentService {
 
       const savedInvestment = await transactionalEntityManager.save(Investment, investment);
 
-      // 7. Transition invoice to FUNDED if fully subscribed
+      // 7. Emit structured log for the investment commitment
+      const truncatedWallet =
+        investorWallet.length >= 8
+          ? `${investorWallet.slice(0, 4)}…${investorWallet.slice(-4)}`
+          : investorWallet;
+      const sharePercent = amount.dividedBy(netAmount).times(100).toFixed(2);
+
+      logger.info("investment.committed", {
+        investment_id: savedInvestment.id,
+        invoice_id: invoiceId,
+        investor_wallet: truncatedWallet,
+        amount_xlm: stroopsToXlm(BigInt(amount.times(10_000_000).toFixed(0))),
+        share_percent: sharePercent,
+        committed_at: savedInvestment.createdAt?.toISOString() ?? new Date().toISOString(),
+      });
+
+      // 8. Transition invoice to FUNDED if fully subscribed
       const newTotalInvested = totalInvested.plus(amount);
       if (newTotalInvested.gte(netAmount)) {
         const previousStatus = invoice.status;

--- a/src/services/invoice.service.ts
+++ b/src/services/invoice.service.ts
@@ -4,6 +4,8 @@ import { User } from "../models/User.model";
 import { InvoiceStatus, KYCStatus } from "../types/enums";
 import { ServiceError } from "../utils/service-error";
 import { validateInvoiceForPublish } from "../lib/validate-invoice-for-publish";
+import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
+import { logger } from "../observability/logger";
 import type { IPFSService, IPFSUploadResult } from "./ipfs.service";
 
 export interface InvoiceRepositoryContract {
@@ -356,8 +358,18 @@ export class InvoiceService {
       );
     }
 
+    const previousStatus = invoice.status;
     invoice.status = InvoiceStatus.PUBLISHED;
     const updated = await this.invoiceRepository.save(invoice);
+
+    logInvoiceTransition(logger, {
+      invoiceId: updated.id,
+      fromState: previousStatus,
+      toState: InvoiceStatus.PUBLISHED,
+      actorWallet: seller.stellarAddress,
+      reason: "seller_published",
+    });
+
     return this.toDTO(updated);
   }
 

--- a/src/services/marketplace.service.ts
+++ b/src/services/marketplace.service.ts
@@ -9,6 +9,7 @@ export interface MarketplaceFilters {
   maxAmount?: number;
   sort?: "due_date" | "discount_rate" | "amount" | "created_at";
   sortOrder?: "ASC" | "DESC";
+  search?: string;
 }
 
 export interface PaginationOptions {
@@ -69,6 +70,7 @@ export class MarketplaceService {
       maxAmount: filters.maxAmount,
       sort: filters.sort || "due_date",
       sortOrder: filters.sortOrder || "ASC",
+      search: filters.search,
     };
 
     // Validate pagination
@@ -149,6 +151,13 @@ class TypeORMMarketplaceRepository implements MarketplaceRepositoryContract {
     if (filters.maxAmount !== undefined) {
       queryBuilder.andWhere("CAST(invoice.amount AS DECIMAL) <= :maxAmount", {
         maxAmount: filters.maxAmount,
+      });
+    }
+
+    // Apply search filter (case-insensitive match on customer_name)
+    if (filters.search) {
+      queryBuilder.andWhere("LOWER(invoice.customer_name) LIKE :search", {
+        search: `%${filters.search.toLowerCase()}%`,
       });
     }
 

--- a/src/services/settlement.service.ts
+++ b/src/services/settlement.service.ts
@@ -4,10 +4,15 @@ import { Invoice } from "../models/Invoice.model";
 import { Investment } from "../models/Investment.model";
 import { InvoiceStatus, InvestmentStatus } from "../types/enums";
 import { ServiceError } from "../utils/service-error";
+import { computeInvestorReturn } from "../lib/investor-return";
+import { decimalStringToScaledBigInt, scaledBigIntToDecimalString } from "../lib/decimal-bigint";
+import { logInvoiceTransition } from "../lib/invoice-lifecycle-log";
+import { logger } from "../observability/logger";
 
 export interface SettleInvoiceInput {
   invoiceId: string;
   proceeds: string;
+  actorWallet: string;
 }
 
 export interface InvestorSettlement {
@@ -32,7 +37,7 @@ export class SettlementService {
    * pro-rata to their share of the invoice's face value.
    */
   async settleInvoice(input: SettleInvoiceInput): Promise<SettleInvoiceResult> {
-    const { invoiceId, proceeds: proceedsInput } = input;
+    const { invoiceId, proceeds: proceedsInput, actorWallet } = input;
 
     const proceeds = new Decimal(proceedsInput);
     if (proceeds.isNegative() || proceeds.isZero()) {
@@ -74,18 +79,24 @@ export class SettlementService {
         );
       }
 
-      // 4. Distribute proceeds pro-rata to each investor's share of the face value
-      const faceValue = new Decimal(invoice.amount);
+      // 4. Distribute proceeds pro-rata to each investor's share of the total funded amount
+      const totalFunded = investments.reduce(
+        (sum, investment) => sum.plus(new Decimal(investment.investmentAmount)),
+        new Decimal(0),
+      );
+      const totalFundedScaled = decimalStringToScaledBigInt(totalFunded.toFixed(4));
+      const proceedsScaled = decimalStringToScaledBigInt(proceeds.toFixed(4));
       const settlements: InvestorSettlement[] = [];
 
       for (const investment of investments) {
-        const investmentAmount = new Decimal(investment.investmentAmount);
-        const actualReturn = investmentAmount
-          .times(proceeds)
-          .dividedBy(faceValue)
-          .toDecimalPlaces(4);
+        const investmentAmountScaled = decimalStringToScaledBigInt(investment.investmentAmount);
+        const actualReturnScaled = computeInvestorReturn(
+          investmentAmountScaled,
+          totalFundedScaled,
+          proceedsScaled,
+        );
 
-        investment.actualReturn = actualReturn.toFixed(4);
+        investment.actualReturn = scaledBigIntToDecimalString(actualReturnScaled);
         investment.status = InvestmentStatus.SETTLED;
         await transactionalEntityManager.save(Investment, investment);
 
@@ -98,8 +109,17 @@ export class SettlementService {
       }
 
       // 5. Transition invoice to SETTLED
+      const previousStatus = invoice.status;
       invoice.status = InvoiceStatus.SETTLED;
       await transactionalEntityManager.save(Invoice, invoice);
+
+      logInvoiceTransition(logger, {
+        invoiceId: invoice.id,
+        fromState: previousStatus,
+        toState: InvoiceStatus.SETTLED,
+        actorWallet,
+        reason: "admin_settled",
+      });
 
       return {
         invoiceId: invoice.id,

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,73 @@
+import { Repository, DataSource, SelectQueryBuilder } from "typeorm";
+import { Invoice } from "../models/Invoice.model";
+import { InvoiceStatus } from "../types/enums";
+
+export interface InvoiceFilters {
+  sellerId?: string;
+  status?: InvoiceStatus | InvoiceStatus[];
+}
+
+export type Database = DataSource | Repository<Invoice>;
+
+export async function queryInvoicesPage(
+  filters: InvoiceFilters,
+  cursor: string | null,
+  limit: number,
+  db: Database
+): Promise<{ data: Invoice[]; has_more: boolean; next_cursor: string | null }> {
+  let queryBuilder: SelectQueryBuilder<Invoice>;
+  
+  if (db instanceof DataSource) {
+    queryBuilder = db.getRepository(Invoice).createQueryBuilder("invoice");
+  } else {
+    queryBuilder = db.createQueryBuilder("invoice");
+  }
+
+  queryBuilder.where("invoice.deletedAt IS NULL");
+
+  if (filters.sellerId) {
+    queryBuilder.andWhere("invoice.sellerId = :sellerId", { sellerId: filters.sellerId });
+  }
+
+  if (filters.status) {
+    if (Array.isArray(filters.status)) {
+       if (filters.status.length > 0) {
+         queryBuilder.andWhere("invoice.status IN (:...statuses)", { statuses: filters.status });
+       }
+    } else {
+       queryBuilder.andWhere("invoice.status = :status", { status: filters.status });
+    }
+  }
+
+  if (cursor) {
+    const decoded = Buffer.from(cursor, "base64").toString("utf-8");
+    const [createdAtStr, id] = decoded.split("|");
+    const createdAt = new Date(createdAtStr);
+
+    queryBuilder.andWhere(
+      "(invoice.createdAt < :createdAt OR (invoice.createdAt = :createdAt AND invoice.id < :id))",
+      { createdAt, id }
+    );
+  }
+
+  queryBuilder.orderBy("invoice.createdAt", "DESC");
+  queryBuilder.addOrderBy("invoice.id", "DESC");
+
+  queryBuilder.take(limit + 1);
+
+  const results = await queryBuilder.getMany();
+  const hasMore = results.length > limit;
+  const data = hasMore ? results.slice(0, limit) : results;
+
+  let nextCursor = null;
+  if (data.length > 0) {
+    const lastItem = data[data.length - 1];
+    nextCursor = Buffer.from(`${lastItem.createdAt.toISOString()}|${lastItem.id}`).toString("base64");
+  }
+
+  return {
+    data,
+    has_more: hasMore,
+    next_cursor: nextCursor
+  };
+}

--- a/src/utils/webhook-signature.ts
+++ b/src/utils/webhook-signature.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+
+/**
+ * Compute an HMAC-SHA256 signature for a payload using the given secret.
+ */
+export function computeWebhookSignature(payload: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+/**
+ * Verify that a signature matches the expected HMAC-SHA256 of the payload
+ * computed with the given secret.
+ *
+ * Uses constant-time comparison to prevent timing attacks.
+ *
+ * @returns `true` if the signature is valid, `false` otherwise.
+ * Never throws — safe to use in webhook handlers.
+ */
+export function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  secret: string,
+): boolean {
+  try {
+    if (!payload || !signature || !secret) {
+      return false;
+    }
+
+    const expected = computeWebhookSignature(payload, secret);
+
+    // Constant-time comparison
+    if (expected.length !== signature.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}

--- a/src/workers/reconcile-pending-stellar-state.worker.ts
+++ b/src/workers/reconcile-pending-stellar-state.worker.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { DataSource, LessThanOrEqual, Not, IsNull, Repository } from "typeorm";
 import type { AppConfig } from "../config/env";
 import type {
@@ -130,6 +131,14 @@ export class ReconcilePendingStellarStateWorker {
         cutoff,
         this.config.batchSize,
       );
+
+      const cycleId = randomUUID();
+      this.logger.info("Started Stellar reconciliation tick.", {
+        cycle_id: cycleId,
+        pending_count: candidates.length,
+        started_at: startedAt.toISOString(),
+      });
+
       const result: ReconciliationTickResult = {
         ...EMPTY_TICK_RESULT,
         candidatesFetched: candidates.length,
@@ -175,8 +184,12 @@ export class ReconcilePendingStellarStateWorker {
 
       result.durationMs = this.now().getTime() - startedAt.getTime();
 
-      this.logger.info("Completed Stellar reconciliation tick.", {
-        ...result,
+      this.logger.debug("Completed Stellar reconciliation tick.", {
+        cycle_id: cycleId,
+        confirmed_count: result.verified,
+        failed_count: result.failed,
+        skipped_count: result.alreadyVerified,
+        duration_ms: result.durationMs,
       });
 
       return result;

--- a/tests/integration/fractional-investment.integration.test.ts
+++ b/tests/integration/fractional-investment.integration.test.ts
@@ -1,33 +1,32 @@
 import crypto from "crypto";
 import { DataSource } from "typeorm";
+import { Decimal } from "decimal.js";
 import { InvestmentService } from "../../src/services/investment.service";
-import { SettlementService } from "../../src/services/settlement.service";
 import { Invoice } from "../../src/models/Invoice.model";
 import { Investment } from "../../src/models/Investment.model";
 import { InvoiceStatus, InvestmentStatus } from "../../src/types/enums";
 
 /**
- * Minimal in-memory TypeORM stand-in shared by InvestmentService and
- * SettlementService so this test exercises the real funding -> settlement
- * flow end to end without a live database.
+ * Minimal in-memory TypeORM stand-in so this test exercises the real
+ * InvestmentService funding logic end to end without a live database.
  */
+type FakeManager = {
+  createQueryBuilder: (entity: unknown, alias: string) => {
+    setLock: () => unknown;
+    where: (clause: string, params: { id: string }) => unknown;
+    getOne: () => Promise<Invoice | null>;
+  };
+  find: (
+    entity: unknown,
+    options: { where: Record<string, unknown> | Record<string, unknown>[] },
+  ) => Promise<Investment[]>;
+  create: (entity: unknown, data: Partial<Investment>) => Investment | Partial<Investment>;
+  save: (entity: unknown, data: Investment | Invoice) => Promise<Investment | Invoice>;
+};
+
 function createFakeDataSource(invoice: Invoice) {
   const invoices = new Map<string, Invoice>([[invoice.id, invoice]]);
   const investments = new Map<string, Investment>();
-
-  type FakeManager = {
-    createQueryBuilder: (entity: unknown, alias: string) => {
-      setLock: () => unknown;
-      where: (clause: string, params: { id: string }) => unknown;
-      getOne: () => Promise<Invoice | null>;
-    };
-    find: (
-      entity: unknown,
-      options: { where: Record<string, unknown> | Record<string, unknown>[] },
-    ) => Promise<Investment[]>;
-    create: (entity: unknown, data: Partial<Investment>) => Investment | Partial<Investment>;
-    save: (entity: unknown, data: Investment | Invoice) => Promise<Investment | Invoice>;
-  };
 
   const manager: FakeManager = {
     createQueryBuilder: (_entity: unknown, _alias: string) => {
@@ -60,7 +59,7 @@ function createFakeDataSource(invoice: Invoice) {
     },
     create: (entity: unknown, data: Partial<Investment>) => {
       if (entity === Investment) {
-        return { id: crypto.randomUUID(), ...data } as Investment;
+        return { id: crypto.randomUUID(), status: InvestmentStatus.PENDING, ...data } as Investment;
       }
       return data;
     },
@@ -75,8 +74,7 @@ function createFakeDataSource(invoice: Invoice) {
   };
 
   const dataSource = {
-    transaction: async (callback: (manager: FakeManager) => Promise<unknown>) =>
-      callback(manager),
+    transaction: async (callback: (manager: FakeManager) => Promise<unknown>) => callback(manager),
   } as unknown as DataSource;
 
   return { dataSource, invoices, investments };
@@ -86,11 +84,11 @@ function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
   return {
     id: crypto.randomUUID(),
     sellerId: crypto.randomUUID(),
-    invoiceNumber: "INV-SETTLE-001",
+    invoiceNumber: "INV-FRACTIONAL-001",
     customerName: "Customer A",
-    amount: "6000.0000",
+    amount: "10000.0000",
     discountRate: "0.00",
-    netAmount: "6000.0000",
+    netAmount: "10000.0000",
     dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
     ipfsHash: "QmTestHash",
     riskScore: null,
@@ -106,62 +104,60 @@ function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
   } as Invoice;
 }
 
-describe("Settlement integration: funding multiple investors then settling", () => {
-  it("distributes proceeds pro-rata to each investor and marks the invoice settled", async () => {
+describe("Fractional investment integration: splitting funded amount across multiple investors", () => {
+  it("transitions to funded after the third commitment with correct, rounding-free share percentages", async () => {
     const invoice = createInvoice();
     const { dataSource, invoices, investments } = createFakeDataSource(invoice);
-
     const investmentService = new InvestmentService(dataSource);
-    const settlementService = new SettlementService(dataSource);
 
-    const investorAId = crypto.randomUUID();
-    const investorBId = crypto.randomUUID();
+    const investorA = { id: crypto.randomUUID(), wallet: "GINVESTORA1234567890ABCDEFGHIJKLMNOPQRSTUVWXY" };
+    const investorB = { id: crypto.randomUUID(), wallet: "GINVESTORB1234567890ABCDEFGHIJKLMNOPQRSTUVWXY" };
+    const investorC = { id: crypto.randomUUID(), wallet: "GINVESTORC1234567890ABCDEFGHIJKLMNOPQRSTUVWXY" };
 
     const investmentA = await investmentService.createInvestment({
       invoiceId: invoice.id,
-      investorId: investorAId,
+      investorId: investorA.id,
       investmentAmount: "4000.0000",
-      investorWallet: "GINVESTORA1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      investorWallet: investorA.wallet,
     });
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.PUBLISHED);
 
     const investmentB = await investmentService.createInvestment({
       invoiceId: invoice.id,
-      investorId: investorBId,
-      investmentAmount: "2000.0000",
-      investorWallet: "GINVESTORB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      investorId: investorB.id,
+      investmentAmount: "3000.0000",
+      investorWallet: investorB.wallet,
+    });
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.PUBLISHED);
+
+    const investmentC = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorC.id,
+      investmentAmount: "3000.0000",
+      investorWallet: investorC.wallet,
     });
 
-    // Simulate confirmed on-chain payment for both investments before settlement.
-    for (const investment of [investmentA, investmentB]) {
-      const stored = investments.get(investment.id)!;
-      stored.status = InvestmentStatus.CONFIRMED;
-      investments.set(investment.id, stored);
-    }
-
-    // Invoice reaches FUNDED once fully subscribed (asserted by InvestmentService already);
-    // settlement requires FUNDED status.
+    // Invoice transitions to FUNDED only after the third commitment reaches face value.
     expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.FUNDED);
 
-    const result = await settlementService.settleInvoice({
-      invoiceId: invoice.id,
-      proceeds: "6600.0000",
-      actorWallet: "GADMINWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-    });
+    const allInvestments = [investmentA, investmentB, investmentC];
+    expect(investments.size).toBe(3);
 
-    const returnByInvestor = new Map(
-      result.settlements.map((settlement) => [settlement.investorId, settlement.actualReturn]),
+    const totalFunded = allInvestments.reduce(
+      (sum, investment) => sum.plus(new Decimal(investment.investmentAmount)),
+      new Decimal(0),
+    );
+    expect(totalFunded.toFixed(4)).toBe("10000.0000");
+
+    const sharePercentages = allInvestments.map((investment) =>
+      new Decimal(investment.investmentAmount).dividedBy(totalFunded).times(100),
     );
 
-    expect(returnByInvestor.get(investorAId)).toBe("4400.0000");
-    expect(returnByInvestor.get(investorBId)).toBe("2200.0000");
+    expect(sharePercentages[0].toFixed(2)).toBe("40.00");
+    expect(sharePercentages[1].toFixed(2)).toBe("30.00");
+    expect(sharePercentages[2].toFixed(2)).toBe("30.00");
 
-    expect(result.status).toBe(InvoiceStatus.SETTLED);
-    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.SETTLED);
-
-    const sumOfReturns = result.settlements.reduce(
-      (sum, settlement) => sum + Number(settlement.actualReturn),
-      0,
-    );
-    expect(sumOfReturns).toBeCloseTo(6600, 4);
+    const sumOfShares = sharePercentages.reduce((sum, share) => sum.plus(share), new Decimal(0));
+    expect(sumOfShares.toFixed(10)).toBe("100.0000000000");
   });
 });

--- a/tests/integration/investment-overflow.integration.test.ts
+++ b/tests/integration/investment-overflow.integration.test.ts
@@ -1,0 +1,157 @@
+import crypto from "crypto";
+import { DataSource } from "typeorm";
+import { Decimal } from "decimal.js";
+import { InvestmentService } from "../../src/services/investment.service";
+import { Invoice } from "../../src/models/Invoice.model";
+import { Investment } from "../../src/models/Investment.model";
+import { InvoiceStatus, InvestmentStatus } from "../../src/types/enums";
+import { ServiceError } from "../../src/utils/service-error";
+
+/**
+ * Minimal in-memory TypeORM stand-in so this test exercises the real
+ * InvestmentService funding logic end to end without a live database.
+ */
+type FakeManager = {
+  createQueryBuilder: (entity: unknown, alias: string) => {
+    setLock: () => unknown;
+    where: (clause: string, params: { id: string }) => unknown;
+    getOne: () => Promise<Invoice | null>;
+  };
+  find: (
+    entity: unknown,
+    options: { where: Record<string, unknown> | Record<string, unknown>[] },
+  ) => Promise<Investment[]>;
+  create: (entity: unknown, data: Partial<Investment>) => Investment | Partial<Investment>;
+  save: (entity: unknown, data: Investment | Invoice) => Promise<Investment | Invoice>;
+};
+
+function createFakeDataSource(invoice: Invoice) {
+  const invoices = new Map<string, Invoice>([[invoice.id, invoice]]);
+  const investments = new Map<string, Investment>();
+
+  const manager: FakeManager = {
+    createQueryBuilder: (_entity: unknown, _alias: string) => {
+      let targetId: string | undefined;
+      const builder = {
+        setLock: () => builder,
+        where: (_clause: string, params: { id: string }) => {
+          targetId = params.id;
+          return builder;
+        },
+        getOne: async () => (targetId ? invoices.get(targetId) ?? null : null),
+      };
+      return builder;
+    },
+    find: async (
+      entity: unknown,
+      options: { where: Record<string, unknown> | Record<string, unknown>[] },
+    ) => {
+      if (entity === Investment) {
+        const whereClauses = Array.isArray(options.where) ? options.where : [options.where];
+        return [...investments.values()].filter((investment) =>
+          whereClauses.some((clause) =>
+            Object.entries(clause).every(
+              ([key, value]) => (investment as unknown as Record<string, unknown>)[key] === value,
+            ),
+          ),
+        );
+      }
+      return [];
+    },
+    create: (entity: unknown, data: Partial<Investment>) => {
+      if (entity === Investment) {
+        return { id: crypto.randomUUID(), status: InvestmentStatus.PENDING, ...data } as Investment;
+      }
+      return data;
+    },
+    save: async (entity: unknown, data: Investment | Invoice) => {
+      if (entity === Investment) {
+        investments.set((data as Investment).id, data as Investment);
+      } else if (entity === Invoice) {
+        invoices.set((data as Invoice).id, data as Invoice);
+      }
+      return data;
+    },
+  };
+
+  const dataSource = {
+    transaction: async (callback: (manager: FakeManager) => Promise<unknown>) => callback(manager),
+  } as unknown as DataSource;
+
+  return { dataSource, invoices, investments };
+}
+
+function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: crypto.randomUUID(),
+    sellerId: crypto.randomUUID(),
+    invoiceNumber: "INV-OVERFLOW-001",
+    customerName: "Customer A",
+    amount: "5000.0000",
+    discountRate: "0.00",
+    netAmount: "5000.0000",
+    dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    ipfsHash: "QmTestHash",
+    riskScore: null,
+    status: InvoiceStatus.PUBLISHED,
+    smartContractId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    seller: undefined as unknown as Invoice["seller"],
+    investments: [],
+    transactions: [],
+    ...overrides,
+  } as Invoice;
+}
+
+describe("Investment overflow integration: rejecting commitments exceeding invoice face value", () => {
+  it("rejects a second commitment that would push total funded above face value, then accepts an exact completion", async () => {
+    const invoice = createInvoice();
+    const { dataSource, invoices, investments } = createFakeDataSource(invoice);
+    const investmentService = new InvestmentService(dataSource);
+
+    const investorA = { id: crypto.randomUUID(), wallet: "GINVESTORA1234567890ABCDEFGHIJKLMNOPQRSTUVWXY" };
+    const investorB = { id: crypto.randomUUID(), wallet: "GINVESTORB1234567890ABCDEFGHIJKLMNOPQRSTUVWXY" };
+
+    await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorA.id,
+      investmentAmount: "4000.0000",
+      investorWallet: investorA.wallet,
+    });
+    expect(investments.size).toBe(1);
+
+    await expect(
+      investmentService.createInvestment({
+        invoiceId: invoice.id,
+        investorId: investorB.id,
+        investmentAmount: "2000.0000",
+        investorWallet: investorB.wallet,
+      }),
+    ).rejects.toMatchObject({
+      code: "INSUFFICIENT_CAPACITY",
+      statusCode: 400,
+    });
+
+    // Total funded remains unchanged after the rejected commitment.
+    expect(investments.size).toBe(1);
+    const totalFundedAfterRejection = [...investments.values()].reduce(
+      (sum, investment) => sum.plus(new Decimal(investment.investmentAmount)),
+      new Decimal(0),
+    );
+    expect(totalFundedAfterRejection.toFixed(4)).toBe("4000.0000");
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.PUBLISHED);
+
+    // A commitment of exactly 1000 completes the invoice and is accepted.
+    const completingInvestment = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorB.id,
+      investmentAmount: "1000.0000",
+      investorWallet: investorB.wallet,
+    });
+    expect(completingInvestment).toBeDefined();
+    expect(investments.size).toBe(2);
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.FUNDED);
+  });
+});

--- a/tests/integration/invoice-search.integration.test.ts
+++ b/tests/integration/invoice-search.integration.test.ts
@@ -1,0 +1,96 @@
+import crypto from "crypto";
+import { MarketplaceService, MarketplaceRepositoryContract } from "../../src/services/marketplace.service";
+import { Invoice } from "../../src/models/Invoice.model";
+import { InvoiceStatus } from "../../src/types/enums";
+
+/**
+ * In-memory repository that implements case-insensitive search on
+ * customer_name, mirroring the real TypeORM repository's LIKE filter.
+ */
+function createFakeMarketplaceRepository(invoices: Invoice[]): MarketplaceRepositoryContract {
+  return {
+    async findPublishedInvoices(filters) {
+      const statuses = filters.status && filters.status.length > 0 ? filters.status : [InvoiceStatus.PUBLISHED];
+      let matched = invoices.filter((invoice) => statuses.includes(invoice.status));
+
+      if (filters.search) {
+        const term = filters.search.toLowerCase();
+        matched = matched.filter((inv) =>
+          inv.customerName.toLowerCase().includes(term),
+        );
+      }
+
+      return { invoices: matched, total: matched.length };
+    },
+  };
+}
+
+function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: crypto.randomUUID(),
+    sellerId: crypto.randomUUID(),
+    invoiceNumber: `INV-${crypto.randomUUID().slice(0, 8)}`,
+    customerName: "Customer",
+    amount: "1000.0000",
+    discountRate: "5.00",
+    netAmount: "950.0000",
+    dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    ipfsHash: "QmTestHash",
+    riskScore: null,
+    status: InvoiceStatus.PUBLISHED,
+    smartContractId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    seller: undefined as unknown as Invoice["seller"],
+    investments: [],
+    transactions: [],
+    ...overrides,
+  } as Invoice;
+}
+
+describe("Invoice search: partial title match (case-insensitive)", () => {
+  const alphaInvoice = createInvoice({ customerName: "Alpha Invoice" });
+  const betaSupply = createInvoice({ customerName: "Beta Supply" });
+  const alphaProject = createInvoice({ customerName: "Alpha project supplies" });
+
+  const allInvoices = [alphaInvoice, betaSupply, alphaProject];
+
+  let service: MarketplaceService;
+
+  beforeEach(() => {
+    service = new MarketplaceService({
+      marketplaceRepository: createFakeMarketplaceRepository(allInvoices),
+    });
+  });
+
+  it("returns two invoices when searching for 'alpha' (title match)", async () => {
+    const result = await service.getPublishedInvoices({ search: "alpha" });
+    expect(result.data).toHaveLength(2);
+    const names = result.data.map((i) => i.customerName);
+    expect(names).toContain("Alpha Invoice");
+    expect(names).toContain("Alpha project supplies");
+  });
+
+  it("returns one invoice when searching for 'beta'", async () => {
+    const result = await service.getPublishedInvoices({ search: "beta" });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].customerName).toBe("Beta Supply");
+  });
+
+  it("returns empty array for no-match search with 200-style response", async () => {
+    const result = await service.getPublishedInvoices({ search: "zzznomatch" });
+    expect(result.data).toHaveLength(0);
+    expect(result.meta.total).toBe(0);
+  });
+
+  it("search is case-insensitive", async () => {
+    const result = await service.getPublishedInvoices({ search: "ALPHA" });
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("returns all invoices when no search term is provided", async () => {
+    const result = await service.getPublishedInvoices({});
+    expect(result.data).toHaveLength(3);
+  });
+});

--- a/tests/integration/marketplace-listing.integration.test.ts
+++ b/tests/integration/marketplace-listing.integration.test.ts
@@ -1,0 +1,104 @@
+import crypto from "crypto";
+import { MarketplaceService, MarketplaceRepositoryContract } from "../../src/services/marketplace.service";
+import { Invoice } from "../../src/models/Invoice.model";
+import { InvoiceStatus } from "../../src/types/enums";
+
+/**
+ * In-memory stand-in for the TypeORM-backed marketplace repository. Mirrors
+ * the real repository's status filtering (defaulting to PUBLISHED, or the
+ * exact statuses requested) so this test exercises the real
+ * MarketplaceService filtering logic end to end without a live database.
+ */
+function createFakeMarketplaceRepository(invoices: Invoice[]): MarketplaceRepositoryContract {
+  return {
+    async findPublishedInvoices(filters) {
+      const statuses = filters.status && filters.status.length > 0 ? filters.status : [InvoiceStatus.PUBLISHED];
+      const matched = invoices.filter((invoice) => statuses.includes(invoice.status));
+      return { invoices: matched, total: matched.length };
+    },
+  };
+}
+
+function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  return {
+    id: crypto.randomUUID(),
+    sellerId: crypto.randomUUID(),
+    invoiceNumber: `INV-${crypto.randomUUID().slice(0, 8)}`,
+    customerName: "Customer",
+    amount: "1000.0000",
+    discountRate: "5.00",
+    netAmount: "950.0000",
+    dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    ipfsHash: "QmTestHash",
+    riskScore: null,
+    status: InvoiceStatus.DRAFT,
+    smartContractId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    seller: undefined as unknown as Invoice["seller"],
+    investments: [],
+    transactions: [],
+    ...overrides,
+  } as Invoice;
+}
+
+describe("Marketplace listing integration: filtering invoices by status", () => {
+  const draftInvoice = createInvoice({ status: InvoiceStatus.DRAFT });
+  const publishedInvoiceA = createInvoice({ status: InvoiceStatus.PUBLISHED });
+  const publishedInvoiceB = createInvoice({ status: InvoiceStatus.PUBLISHED });
+  const fundedInvoice = createInvoice({ status: InvoiceStatus.FUNDED });
+  const settledInvoice = createInvoice({ status: InvoiceStatus.SETTLED });
+
+  const allInvoices = [draftInvoice, publishedInvoiceA, publishedInvoiceB, fundedInvoice, settledInvoice];
+
+  function createService(): MarketplaceService {
+    return new MarketplaceService({
+      marketplaceRepository: createFakeMarketplaceRepository(allInvoices),
+    });
+  }
+
+  it("returns only published invoices by default", async () => {
+    const marketplaceService = createService();
+
+    const result = await marketplaceService.getPublishedInvoices();
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data.map((invoice) => invoice.id).sort()).toEqual(
+      [publishedInvoiceA.id, publishedInvoiceB.id].sort(),
+    );
+    expect(result.data.every((invoice) => invoice.status === InvoiceStatus.PUBLISHED)).toBe(true);
+  });
+
+  it("returns only funded invoices when filtered by status=funded", async () => {
+    const marketplaceService = createService();
+
+    const result = await marketplaceService.getPublishedInvoices({ status: [InvoiceStatus.FUNDED] });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(fundedInvoice.id);
+  });
+
+  it("returns only settled invoices when filtered by status=settled", async () => {
+    const marketplaceService = createService();
+
+    const result = await marketplaceService.getPublishedInvoices({ status: [InvoiceStatus.SETTLED] });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(settledInvoice.id);
+  });
+
+  it("never includes draft invoices, regardless of the filter applied", async () => {
+    const marketplaceService = createService();
+
+    const results = await Promise.all([
+      marketplaceService.getPublishedInvoices(),
+      marketplaceService.getPublishedInvoices({ status: [InvoiceStatus.FUNDED] }),
+      marketplaceService.getPublishedInvoices({ status: [InvoiceStatus.SETTLED] }),
+    ]);
+
+    for (const result of results) {
+      expect(result.data.some((invoice) => invoice.id === draftInvoice.id)).toBe(false);
+    }
+  });
+});

--- a/tests/integration/notification-mark-read.integration.test.ts
+++ b/tests/integration/notification-mark-read.integration.test.ts
@@ -1,0 +1,130 @@
+import crypto from "crypto";
+import { NotificationService, NotificationRepositoryContract, NotificationPage } from "../../src/services/notification.service";
+import { NotificationType } from "../../src/types/enums";
+
+interface StoredNotification {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  read: boolean;
+  timestamp: Date;
+}
+
+/**
+ * In-memory notification repository for integration testing.
+ */
+function createFakeNotificationRepository(): NotificationRepositoryContract & { store: StoredNotification[] } {
+  const store: StoredNotification[] = [];
+
+  return {
+    store,
+
+    async create(userId, type, title, message) {
+      const notif: StoredNotification = {
+        id: crypto.randomUUID(),
+        userId,
+        type,
+        title,
+        message,
+        read: false,
+        timestamp: new Date(),
+      };
+      store.push(notif);
+      return notif as import("../../src/models/Notification.model").Notification;
+    },
+
+    async findByIdAndUserId(id, userId) {
+      return (store.find((n) => n.id === id && n.userId === userId) ?? null) as import("../../src/models/Notification.model").Notification | null;
+    },
+
+    async markRead(id, userId) {
+      const notif = store.find((n) => n.id === id && n.userId === userId);
+      if (!notif) throw new Error("Not found");
+      notif.read = true;
+      return notif as import("../../src/models/Notification.model").Notification;
+    },
+
+    async list(options) {
+      let filtered = store.filter((n) => n.userId === options.userId);
+      if (options.read !== undefined) {
+        filtered = filtered.filter((n) => n.read === options.read);
+      }
+      const page = options.page ?? 1;
+      const limit = options.limit ?? 20;
+      return {
+        data: filtered.slice((page - 1) * limit, page * limit) as import("../../src/models/Notification.model").Notification[],
+        meta: { total: filtered.length, page, limit, totalPages: Math.ceil(filtered.length / limit) },
+      };
+    },
+  };
+}
+
+describe("Notification mark-as-read integration", () => {
+  let repo: ReturnType<typeof createFakeNotificationRepository>;
+  let service: NotificationService;
+
+  beforeEach(() => {
+    repo = createFakeNotificationRepository();
+    service = new NotificationService(repo);
+  });
+
+  it("marks a notification as read and persists the status", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.INVOICE,
+      "Invoice published",
+      "Your invoice has been published.",
+    );
+
+    expect(notif.read).toBe(false);
+
+    const marked = await service.markNotificationRead(notif.id, "wallet-1");
+    expect(marked.read).toBe(true);
+
+    // Verify persistence via the store
+    const stored = repo.store.find((n) => n.id === notif.id);
+    expect(stored?.read).toBe(true);
+  });
+
+  it("unread count decrements after marking as read", async () => {
+    await service.createNotification("wallet-1", NotificationType.INVOICE, "A", "a");
+    await service.createNotification("wallet-1", NotificationType.INVESTMENT, "B", "b");
+
+    const before = await service.listNotifications({ userId: "wallet-1", read: false });
+    expect(before.meta.total).toBe(2);
+
+    await service.markNotificationRead(repo.store[0].id, "wallet-1");
+
+    const after = await service.listNotifications({ userId: "wallet-1", read: false });
+    expect(after.meta.total).toBe(1);
+  });
+
+  it("marking an already-read notification is idempotent", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.PAYMENT,
+      "Settlement",
+      "Settlement complete.",
+    );
+
+    await service.markNotificationRead(notif.id, "wallet-1");
+    const second = await service.markNotificationRead(notif.id, "wallet-1");
+
+    expect(second.read).toBe(true);
+  });
+
+  it("cannot mark a notification belonging to another wallet", async () => {
+    const notif = await service.createNotification(
+      "wallet-1",
+      NotificationType.INVOICE,
+      "Invoice",
+      "desc",
+    );
+
+    await expect(
+      service.markNotificationRead(notif.id, "wallet-2"),
+    ).rejects.toThrow("Notification not found");
+  });
+});

--- a/tests/integration/seller-invoice-list.integration.test.ts
+++ b/tests/integration/seller-invoice-list.integration.test.ts
@@ -1,0 +1,170 @@
+import { DataSource } from "typeorm";
+import { Investment } from "../../src/models/Investment.model";
+import { Transaction } from "../../src/models/Transaction.model";
+import { Invoice } from "../../src/models/Invoice.model";
+import { User } from "../../src/models/User.model";
+import { KYCVerification } from "../../src/models/KYCVerification.model";
+import { Notification } from "../../src/models/Notification.model";
+import { AuthChallenge } from "../../src/models/AuthChallenge.model";
+import { InvoiceStatus, UserType, KYCStatus } from "../../src/types/enums";
+import { createInvoiceService, InvoiceService } from "../../src/services/invoice.service";
+import type { IPFSService } from "../../src/services/ipfs.service";
+
+describe("Seller invoice list integration: no cross-seller leakage", () => {
+  let dataSource: DataSource;
+  let invoiceService: InvoiceService;
+  let sellerA: User;
+  let sellerB: User;
+
+  const noopIpfsService = {} as IPFSService;
+
+  beforeAll(async () => {
+    const databaseUrl = process.env.DATABASE_URL;
+
+    if (!databaseUrl) {
+      console.warn("DATABASE_URL not set, skipping integration tests");
+      return;
+    }
+
+    dataSource = new DataSource({
+      type: "postgres",
+      url: databaseUrl,
+      entities: [
+        User,
+        Invoice,
+        Investment,
+        Transaction,
+        KYCVerification,
+        Notification,
+        AuthChallenge,
+      ],
+      synchronize: true,
+      logging: false,
+      dropSchema: true,
+    });
+
+    await dataSource.initialize();
+
+    const userRepository = dataSource.getRepository(User);
+    sellerA = await userRepository.save(
+      userRepository.create({
+        stellarAddress: "GSELLERA123",
+        email: "sellerA@test.com",
+        userType: UserType.SELLER,
+        kycStatus: KYCStatus.APPROVED,
+      }),
+    );
+
+    sellerB = await userRepository.save(
+      userRepository.create({
+        stellarAddress: "GSELLERB123",
+        email: "sellerB@test.com",
+        userType: UserType.SELLER,
+        kycStatus: KYCStatus.APPROVED,
+      }),
+    );
+
+    const invoiceRepository = dataSource.getRepository(Invoice);
+
+    const sellerAInvoices = [
+      { invoiceNumber: "INV-A-001", status: InvoiceStatus.DRAFT },
+      { invoiceNumber: "INV-A-002", status: InvoiceStatus.PUBLISHED },
+      { invoiceNumber: "INV-A-003", status: InvoiceStatus.FUNDED },
+    ];
+    for (const overrides of sellerAInvoices) {
+      await invoiceRepository.save(
+        invoiceRepository.create({
+          sellerId: sellerA.id,
+          customerName: "Customer A",
+          amount: "1000.0000",
+          discountRate: "5.00",
+          netAmount: "950.0000",
+          dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          ...overrides,
+        }),
+      );
+    }
+
+    const sellerBInvoices = [
+      { invoiceNumber: "INV-B-001", status: InvoiceStatus.PUBLISHED },
+      { invoiceNumber: "INV-B-002", status: InvoiceStatus.SETTLED },
+    ];
+    for (const overrides of sellerBInvoices) {
+      await invoiceRepository.save(
+        invoiceRepository.create({
+          sellerId: sellerB.id,
+          customerName: "Customer B",
+          amount: "2000.0000",
+          discountRate: "5.00",
+          netAmount: "1900.0000",
+          dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          ...overrides,
+        }),
+      );
+    }
+
+    invoiceService = createInvoiceService(dataSource, noopIpfsService);
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  it("returns exactly seller A's 3 invoices with no seller B leakage", async () => {
+    if (!process.env.DATABASE_URL) {
+      return;
+    }
+
+    const result = await invoiceService.getInvoicesBySellerId({
+      sellerId: sellerA.id,
+      take: 20,
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.invoices).toHaveLength(3);
+    expect(result.invoices.every((invoice) => invoice.sellerId === sellerA.id)).toBe(true);
+
+    const sellerBInvoiceNumbers = ["INV-B-001", "INV-B-002"];
+    expect(
+      result.invoices.some((invoice) => sellerBInvoiceNumbers.includes(invoice.invoiceNumber)),
+    ).toBe(false);
+  });
+
+  it("includes invoices in all states (draft, published, funded)", async () => {
+    if (!process.env.DATABASE_URL) {
+      return;
+    }
+
+    const result = await invoiceService.getInvoicesBySellerId({
+      sellerId: sellerA.id,
+      take: 20,
+    });
+
+    const statuses = result.invoices.map((invoice) => invoice.status);
+    expect(statuses).toEqual(
+      expect.arrayContaining([InvoiceStatus.DRAFT, InvoiceStatus.PUBLISHED, InvoiceStatus.FUNDED]),
+    );
+  });
+
+  it("returns exactly seller B's 2 invoices with no seller A leakage", async () => {
+    if (!process.env.DATABASE_URL) {
+      return;
+    }
+
+    const result = await invoiceService.getInvoicesBySellerId({
+      sellerId: sellerB.id,
+      take: 20,
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.invoices).toHaveLength(2);
+    expect(result.invoices.every((invoice) => invoice.sellerId === sellerB.id)).toBe(true);
+
+    const statuses = result.invoices.map((invoice) => invoice.status);
+    expect(statuses).toEqual(
+      expect.arrayContaining([InvoiceStatus.PUBLISHED, InvoiceStatus.SETTLED]),
+    );
+  });
+});

--- a/tests/integration/settlement.integration.test.ts
+++ b/tests/integration/settlement.integration.test.ts
@@ -119,7 +119,7 @@ describe("Settlement integration: rejecting settlement of non-fully-funded invoi
         proceeds: "6000.0000",
         actorWallet: "GADMIN",
       }),
-    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+    ).rejects.toThrow(/Cannot settle an invoice with status published/);
   });
 
   it("should reject settlement of a partially funded invoice", async () => {
@@ -152,7 +152,7 @@ describe("Settlement integration: rejecting settlement of non-fully-funded invoi
         proceeds: "6000.0000",
         actorWallet: "GADMIN",
       }),
-    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+    ).rejects.toThrow(/Cannot settle an invoice with status published/);
   });
 
   it("should succeed when invoice is fully funded", async () => {
@@ -255,5 +255,40 @@ describe("Settlement integration: funding multiple investors then settling", () 
       0,
     );
     expect(sumOfReturns).toBeCloseTo(6600, 4);
+  });
+});
+
+describe("Settlement integration: single investor 100% share", () => {
+  it("returns the full proceeds to the only investor", async () => {
+    const invoice = createInvoice();
+    const { dataSource, invoices, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    const investorId = crypto.randomUUID();
+    const investment = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId,
+      investmentAmount: "6000.0000",
+      investorWallet: "GINVESTOR100000000000000000000000000000000000000000000000",
+    });
+
+    const stored = investments.get(investment.id)!;
+    stored.status = InvestmentStatus.CONFIRMED;
+    investments.set(investment.id, stored);
+
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.FUNDED);
+
+    const result = await settlementService.settleInvoice({
+      invoiceId: invoice.id,
+      proceeds: "3300.0000",
+      actorWallet: "GADMINWALLET1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    });
+
+    expect(result.status).toBe(InvoiceStatus.SETTLED);
+    expect(result.settlements).toHaveLength(1);
+    expect(result.settlements[0]?.actualReturn).toBe("3300.0000");
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.SETTLED);
   });
 });

--- a/tests/integration/settlement.integration.test.ts
+++ b/tests/integration/settlement.integration.test.ts
@@ -106,6 +106,98 @@ function createInvoice(overrides: Partial<Invoice> = {}): Invoice {
   } as Invoice;
 }
 
+describe("Settlement integration: rejecting settlement of non-fully-funded invoices (#88)", () => {
+  it("should reject settlement of a published invoice (no investments)", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource } = createFakeDataSource(invoice);
+
+    const settlementService = new SettlementService(dataSource);
+
+    await expect(
+      settlementService.settleInvoice({
+        invoiceId: invoice.id,
+        proceeds: "6000.0000",
+        actorWallet: "GADMIN",
+      }),
+    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+  });
+
+  it("should reject settlement of a partially funded invoice", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    // Fund only 50%
+    const investorAId = crypto.randomUUID();
+    const investmentA = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorAId,
+      investmentAmount: "3000.0000",
+      investorWallet: "GINVESTORA",
+    });
+
+    // Mark confirmed but invoice is not fully funded
+    const stored = investments.get(investmentA.id)!;
+    stored.status = InvestmentStatus.CONFIRMED;
+    investments.set(investmentA.id, stored);
+
+    // Manually set status to PUBLISHED (not FUNDED) since only partial funding
+    invoice.status = InvoiceStatus.PUBLISHED;
+
+    await expect(
+      settlementService.settleInvoice({
+        invoiceId: invoice.id,
+        proceeds: "6000.0000",
+        actorWallet: "GADMIN",
+      }),
+    ).rejects.toThrow(/INVALID_INVOICE_STATUS/);
+  });
+
+  it("should succeed when invoice is fully funded", async () => {
+    const invoice = createInvoice({ status: InvoiceStatus.PUBLISHED });
+    const { dataSource, invoices, investments } = createFakeDataSource(invoice);
+
+    const investmentService = new InvestmentService(dataSource);
+    const settlementService = new SettlementService(dataSource);
+
+    const investorAId = crypto.randomUUID();
+    const investorBId = crypto.randomUUID();
+
+    const investmentA = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorAId,
+      investmentAmount: "4000.0000",
+      investorWallet: "GINVESTORA",
+    });
+
+    const investmentB = await investmentService.createInvestment({
+      invoiceId: invoice.id,
+      investorId: investorBId,
+      investmentAmount: "2000.0000",
+      investorWallet: "GINVESTORB",
+    });
+
+    for (const investment of [investmentA, investmentB]) {
+      const stored = investments.get(investment.id)!;
+      stored.status = InvestmentStatus.CONFIRMED;
+      investments.set(investment.id, stored);
+    }
+
+    expect(invoices.get(invoice.id)?.status).toBe(InvoiceStatus.FUNDED);
+
+    const result = await settlementService.settleInvoice({
+      invoiceId: invoice.id,
+      proceeds: "6600.0000",
+      actorWallet: "GADMIN",
+    });
+
+    expect(result.status).toBe(InvoiceStatus.SETTLED);
+    expect(result.settlements).toHaveLength(2);
+  });
+});
+
 describe("Settlement integration: funding multiple investors then settling", () => {
   it("distributes proceeds pro-rata to each investor and marks the invoice settled", async () => {
     const invoice = createInvoice();

--- a/tests/investment.routes.test.ts
+++ b/tests/investment.routes.test.ts
@@ -68,6 +68,7 @@ describe("Investment Routes", () => {
         invoiceId: "invoice-1",
         investorId: mockUser.id,
         investmentAmount: "500.0000",
+        investorWallet: mockUser.stellarAddress,
       });
     });
 

--- a/tests/investment.service.test.ts
+++ b/tests/investment.service.test.ts
@@ -5,6 +5,8 @@ import { Investment } from "../src/models/Investment.model";
 import { InvoiceStatus, InvestmentStatus } from "../src/types/enums";
 import { ServiceError } from "../src/utils/service-error";
 
+const INVESTOR_WALLET = "GINVESTORWALLET1234567890ABCDEFGHIJKLMNOPQRSTUV";
+
 describe("InvestmentService", () => {
   let mockDataSource: jest.Mocked<DataSource>;
   let mockEntityManager: jest.Mocked<EntityManager>;
@@ -51,6 +53,7 @@ describe("InvestmentService", () => {
       invoiceId: "invoice-1",
       investorId: "investor-1",
       investmentAmount: "475.0000",
+      investorWallet: INVESTOR_WALLET,
     };
 
     const result = await investmentService.createInvestment(input);
@@ -74,6 +77,7 @@ describe("InvestmentService", () => {
       invoiceId: "invoice-1",
       investorId: "investor-1",
       investmentAmount: "950.0000",
+      investorWallet: INVESTOR_WALLET,
     };
 
     await investmentService.createInvestment(input);
@@ -93,6 +97,7 @@ describe("InvestmentService", () => {
       invoiceId: "invoice-1",
       investorId: "investor-1",
       investmentAmount: "500.0000", // 500 + 500 > 950
+      investorWallet: INVESTOR_WALLET,
     };
 
     await expect(investmentService.createInvestment(input)).rejects.toThrow(
@@ -108,6 +113,7 @@ describe("InvestmentService", () => {
       invoiceId: "invoice-1",
       investorId: "seller-1", // Same as invoice seller
       investmentAmount: "100.0000",
+      investorWallet: INVESTOR_WALLET,
     };
 
     await expect(investmentService.createInvestment(input)).rejects.toThrow(
@@ -120,6 +126,7 @@ describe("InvestmentService", () => {
       invoiceId: "invoice-1",
       investorId: "investor-1",
       investmentAmount: "-100.0000",
+      investorWallet: INVESTOR_WALLET,
     };
 
     await expect(investmentService.createInvestment(input)).rejects.toThrow(

--- a/tests/investor-return.test.ts
+++ b/tests/investor-return.test.ts
@@ -1,0 +1,30 @@
+import { computeInvestorReturn } from "../src/lib/investor-return";
+
+describe("computeInvestorReturn", () => {
+  it("computes the correct return when division is exact", () => {
+    expect(computeInvestorReturn(2000n, 4000n, 4400n)).toBe(2200n);
+  });
+
+  it("floors the result when division is not exact, without rounding up", () => {
+    // (1000 * 1000) / 3000 = 333.33... -> floors to 333
+    expect(computeInvestorReturn(1000n, 3000n, 1000n)).toBe(333n);
+  });
+
+  it("returns the full settled proceeds when investedAmount equals totalFunded", () => {
+    expect(computeInvestorReturn(5000n, 5000n, 7500n)).toBe(7500n);
+  });
+
+  it("returns 0 when investedAmount is 0", () => {
+    expect(computeInvestorReturn(0n, 5000n, 7500n)).toBe(0n);
+  });
+
+  it("throws when totalFunded is zero or negative", () => {
+    expect(() => computeInvestorReturn(100n, 0n, 100n)).toThrow(RangeError);
+    expect(() => computeInvestorReturn(100n, -100n, 100n)).toThrow(RangeError);
+  });
+
+  it("throws on negative investedAmount or settledProceeds", () => {
+    expect(() => computeInvestorReturn(-1n, 1000n, 1000n)).toThrow(RangeError);
+    expect(() => computeInvestorReturn(1n, 1000n, -1000n)).toThrow(RangeError);
+  });
+});

--- a/tests/invoice-lifecycle-log.test.ts
+++ b/tests/invoice-lifecycle-log.test.ts
@@ -1,0 +1,55 @@
+import { logInvoiceTransition } from "../src/lib/invoice-lifecycle-log";
+import { InvoiceStatus } from "../src/types/enums";
+import type { AppLogger } from "../src/observability/logger";
+
+function createMockLogger(): jest.Mocked<AppLogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  } as unknown as jest.Mocked<AppLogger>;
+}
+
+describe("logInvoiceTransition", () => {
+  it("emits an info log with all six fields, truncating the actor wallet", () => {
+    const logger = createMockLogger();
+
+    logInvoiceTransition(logger, {
+      invoiceId: "invoice-123",
+      fromState: InvoiceStatus.PUBLISHED,
+      toState: InvoiceStatus.FUNDED,
+      actorWallet: "GABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      reason: "fully_funded",
+    });
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      "Invoice lifecycle state transition.",
+      expect.objectContaining({
+        invoice_id: "invoice-123",
+        from_state: InvoiceStatus.PUBLISHED,
+        to_state: InvoiceStatus.FUNDED,
+        actor_wallet: "GABC...WXYZ",
+        reason: "fully_funded",
+        transitioned_at: expect.any(String),
+      }),
+    );
+  });
+
+  it("uses a machine-readable reason string, not free text", () => {
+    const logger = createMockLogger();
+
+    logInvoiceTransition(logger, {
+      invoiceId: "invoice-456",
+      fromState: InvoiceStatus.DRAFT,
+      toState: InvoiceStatus.PUBLISHED,
+      actorWallet: "GSELLER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      reason: "seller_published",
+    });
+
+    const metadata = logger.info.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(metadata.reason).toMatch(/^[a-z_]+$/);
+  });
+});

--- a/tests/invoice.service.test.ts
+++ b/tests/invoice.service.test.ts
@@ -353,7 +353,7 @@ describe("InvoiceService", () => {
       ...mockInvoice,
       dueDate: new Date(Date.now() + 48 * 60 * 60 * 1000),
       ipfsHash: "QmTestHash",
-      seller: { kycStatus: "approved" },
+      seller: { kycStatus: "approved", stellarAddress: "GSELLERWALLET1234567890ABCDEFGHIJKLMNOPQRSTUV" },
     } as Invoice;
 
     it("should transition draft invoice to published", async () => {
@@ -373,7 +373,7 @@ describe("InvoiceService", () => {
       const soonDueInvoice = {
         ...mockInvoice,
         dueDate: new Date(Date.now() + 60 * 60 * 1000), // 1 hour in future
-        seller: { kycStatus: "approved" },
+        seller: { kycStatus: "approved", stellarAddress: "GSELLERWALLET1234567890ABCDEFGHIJKLMNOPQRSTUV" },
       };
       mockInvoiceRepository.findOne.mockResolvedValue(soonDueInvoice);
 
@@ -393,7 +393,7 @@ describe("InvoiceService", () => {
         ...mockInvoice,
         status: InvoiceStatus.SETTLED,
         dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-        seller: { kycStatus: "approved" },
+        seller: { kycStatus: "approved", stellarAddress: "GSELLERWALLET1234567890ABCDEFGHIJKLMNOPQRSTUV" },
       };
       mockInvoiceRepository.findOne.mockResolvedValue(settledInvoice);
 
@@ -440,7 +440,7 @@ describe("InvoiceService", () => {
       const invoiceWithPendingKYC = {
         ...publishableInvoice,
         status: InvoiceStatus.DRAFT,
-        seller: { kycStatus: "pending" },
+        seller: { kycStatus: "pending", stellarAddress: "GSELLERWALLET1234567890ABCDEFGHIJKLMNOPQRSTUV" },
       };
       mockInvoiceRepository.findOne.mockResolvedValue(invoiceWithPendingKYC);
 

--- a/tests/observability.test.ts
+++ b/tests/observability.test.ts
@@ -137,6 +137,31 @@ describe("Observability", () => {
 
   });
 
+  it("logs structured auth failure metadata after a 401 response", async () => {
+    const logger = new CaptureLogger();
+    const app = createApp({
+      authService: createAuthServiceStub(),
+      logger,
+      metricsEnabled: true,
+      metricsRegistry: new MetricsRegistry(),
+    });
+
+    await request(app).get("/api/v1/auth/me").expect(401);
+
+    const authFailureLog = logger.entries.find(
+      (entry) => entry.level === "warn" && entry.message === "API authentication failure.",
+    );
+
+    expect(authFailureLog).toBeDefined();
+    expect(authFailureLog?.metadata).toMatchObject({
+      method: "GET",
+      path: "/api/v1/auth/me",
+      reason: "missing_token",
+      truncated_address: null,
+      failed_at: expect.any(String),
+    });
+  });
+
   it("exposes Prometheus metrics for matched routes and unmatched requests", async () => {
     const app = createApp({
       authService: createAuthServiceStub(),

--- a/tests/rate-limit-wallet.test.ts
+++ b/tests/rate-limit-wallet.test.ts
@@ -231,4 +231,95 @@ describe("Wallet-based rate limiting", () => {
             .post("/api/v1/test-rate-limit")
             .expect(401);
     });
+
+    it("should reset counter after window expires and allow full quota again", async () => {
+        resetRateLimitStores();
+
+        const shortApp = express();
+        shortApp.use(express.json());
+
+        const limiter = createWalletRateLimiter(
+            { windowMs: 150, maxRequests: 3 },
+            "reset-test",
+        );
+
+        shortApp.post("/test", (req, res, next) => {
+            const authHeader = req.headers.authorization;
+            if (!authHeader?.startsWith("Bearer ")) { res.status(401).json({ error: "Unauthorized" }); return; }
+            const token = authHeader.slice(7);
+            try {
+                const payload = jwt.verify(token, TEST_SECRET) as any;
+                (req as any).user = { id: payload.sub, stellarAddress: payload.stellarAddress };
+                next();
+            } catch { res.status(401).json({ error: "Invalid token" }); }
+        }, limiter, (_req, res) => { res.status(200).json({ success: true }); });
+
+        shortApp.use(createErrorMiddleware(logger));
+
+        const token = createToken(WALLET_A);
+
+        // Exhaust the limit (3 requests)
+        for (let i = 0; i < 3; i++) {
+            await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(200);
+        }
+
+        // 4th request should be rate limited
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(429);
+
+        // Wait for window to expire
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Counter should have reset — 3 more requests should succeed
+        for (let i = 0; i < 3; i++) {
+            await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(200);
+        }
+
+        // 4th request after reset should be rate limited again
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${token}`).expect(429);
+    });
+
+    it("should reset per wallet, not globally", async () => {
+        resetRateLimitStores();
+
+        const shortApp = express();
+        shortApp.use(express.json());
+
+        const limiter = createWalletRateLimiter(
+            { windowMs: 150, maxRequests: 2 },
+            "per-wallet-test",
+        );
+
+        shortApp.post("/test", (req, res, next) => {
+            const authHeader = req.headers.authorization;
+            if (!authHeader?.startsWith("Bearer ")) { res.status(401).json({ error: "Unauthorized" }); return; }
+            const token = authHeader.slice(7);
+            try {
+                const payload = jwt.verify(token, TEST_SECRET) as any;
+                (req as any).user = { id: payload.sub, stellarAddress: payload.stellarAddress };
+                next();
+            } catch { res.status(401).json({ error: "Invalid token" }); }
+        }, limiter, (_req, res) => { res.status(200).json({ success: true }); });
+
+        shortApp.use(createErrorMiddleware(logger));
+
+        const tokenA = createToken(WALLET_A);
+        const tokenB = createToken(WALLET_B);
+
+        // Exhaust wallet A
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(429);
+
+        // Wallet B should still have full quota
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(429);
+
+        // Wait for window to expire
+        await new Promise((resolve) => setTimeout(resolve, 200));
+
+        // Both wallets should have fresh quotas
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenA}`).expect(200);
+        await request(shortApp).post("/test").set("Authorization", `Bearer ${tokenB}`).expect(200);
+    });
 });

--- a/tests/reconcile-pending-stellar-state.worker.test.ts
+++ b/tests/reconcile-pending-stellar-state.worker.test.ts
@@ -164,11 +164,68 @@ describe("ReconcilePendingStellarStateWorker", () => {
           message: "Failed to reconcile pending Stellar state.",
         }),
         expect.objectContaining({
-          level: "info",
+          level: "debug",
           message: "Completed Stellar reconciliation tick.",
         }),
       ]),
     );
+  });
+
+  it("logs cycle start and completion once per cycle with matching cycle_id", async () => {
+    const now = new Date("2026-01-01T00:10:00.000Z");
+    const repository = {
+      findPendingCandidates: jest.fn().mockResolvedValue([
+        createCandidate("investment-1", "hash-1"),
+        createCandidate("investment-2", "hash-2"),
+      ]),
+    };
+    const paymentVerifier = {
+      verifyPayment: jest
+        .fn()
+        .mockResolvedValueOnce(createVerifiedResult("investment-1", "verified"))
+        .mockResolvedValueOnce(createVerifiedResult("investment-2", "already_verified")),
+    };
+    const logger = new CaptureLogger();
+    const worker = new ReconcilePendingStellarStateWorker({
+      repository,
+      paymentVerifier,
+      config: {
+        enabled: true,
+        intervalMs: 1_000,
+        batchSize: 3,
+        gracePeriodMs: 60_000,
+        maxRuntimeMs: 10_000,
+      },
+      logger,
+      now: () => now,
+      yieldControl: jest.fn(async () => undefined),
+    });
+
+    await worker.runTick();
+
+    const startLogs = logger.entries.filter(
+      (entry) => entry.level === "info" && entry.message === "Started Stellar reconciliation tick.",
+    );
+    const completionLogs = logger.entries.filter(
+      (entry) => entry.level === "debug" && entry.message === "Completed Stellar reconciliation tick.",
+    );
+
+    expect(startLogs).toHaveLength(1);
+    expect(completionLogs).toHaveLength(1);
+
+    expect(startLogs[0].metadata).toMatchObject({
+      cycle_id: expect.any(String),
+      pending_count: 2,
+      started_at: now.toISOString(),
+    });
+
+    expect(completionLogs[0].metadata).toMatchObject({
+      cycle_id: startLogs[0].metadata.cycle_id,
+      confirmed_count: 1,
+      failed_count: 0,
+      skipped_count: 1,
+      duration_ms: expect.any(Number),
+    });
   });
 
   it("stops starting new reconciliations once the tick runtime budget is exhausted", async () => {

--- a/tests/unit/auth-failure.test.ts
+++ b/tests/unit/auth-failure.test.ts
@@ -1,0 +1,39 @@
+import jwt from "jsonwebtoken";
+import {
+  buildAuthFailureDetails,
+  truncateWalletAddress,
+} from "../../src/lib/auth-failure";
+
+describe("auth failure helpers", () => {
+  it("truncates wallet addresses consistently", () => {
+    expect(truncateWalletAddress("GABCDEFGHIJKLMNO1234567890")).toBe("GABC...7890");
+    expect(truncateWalletAddress("G123")).toBe("G123");
+    expect(truncateWalletAddress(null)).toBeNull();
+  });
+
+  it("extracts a truncated address from a parseable token", () => {
+    const token = jwt.sign(
+      { sub: "GABCDEFGHIJKLMNO1234567890" },
+      "test-secret",
+      { expiresIn: "1h" },
+    );
+
+    expect(buildAuthFailureDetails(token, "invalid_signature")).toEqual({
+      authFailure: {
+        reason: "invalid_signature",
+        truncatedAddress: "GABC...7890",
+        failedAt: expect.any(String),
+      },
+    });
+  });
+
+  it("returns null truncated addresses for unparseable tokens", () => {
+    expect(buildAuthFailureDetails("not-a-jwt", "invalid_token")).toEqual({
+      authFailure: {
+        reason: "invalid_token",
+        truncatedAddress: null,
+        failedAt: expect.any(String),
+      },
+    });
+  });
+});

--- a/tests/unit/extract-wallet-from-token.test.ts
+++ b/tests/unit/extract-wallet-from-token.test.ts
@@ -1,0 +1,49 @@
+import jwt from "jsonwebtoken";
+import { extractWalletFromToken } from "../../src/lib/extract-wallet-from-token";
+
+const SECRET = "test-secret";
+
+function makeToken(overrides: jwt.SignOptions & { sub?: string } = {}) {
+  const { sub = "GABC1234DEFG5678", ...options } = overrides;
+  return jwt.sign({ sub }, SECRET, { expiresIn: "1h", ...options });
+}
+
+describe("extractWalletFromToken", () => {
+  it("returns the sub claim for a valid token", () => {
+    const token = makeToken();
+    expect(extractWalletFromToken(token, SECRET)).toBe("GABC1234DEFG5678");
+  });
+
+  it("returns null for undefined token", () => {
+    expect(extractWalletFromToken(undefined, SECRET)).toBeNull();
+  });
+
+  it("returns null for empty string token", () => {
+    expect(extractWalletFromToken("", SECRET)).toBeNull();
+  });
+
+  it("returns null for expired token", () => {
+    const token = jwt.sign({ sub: "GABC" }, SECRET, { expiresIn: -1 });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null for invalid signature", () => {
+    const token = jwt.sign({ sub: "GABC" }, "wrong-secret");
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null when sub claim is missing", () => {
+    const token = jwt.sign({ foo: "bar" }, SECRET, { expiresIn: "1h" });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("returns null when sub claim is empty string", () => {
+    const token = jwt.sign({ sub: "" }, SECRET, { expiresIn: "1h" });
+    expect(extractWalletFromToken(token, SECRET)).toBeNull();
+  });
+
+  it("never throws", () => {
+    expect(extractWalletFromToken("not.a.jwt", SECRET)).toBeNull();
+    expect(extractWalletFromToken(undefined, "")).toBeNull();
+  });
+});

--- a/tests/unit/pagination.test.ts
+++ b/tests/unit/pagination.test.ts
@@ -1,0 +1,155 @@
+import { DataSource, Repository, SelectQueryBuilder } from "typeorm";
+import { queryInvoicesPage } from "../../src/utils/pagination";
+import { Invoice } from "../../src/models/Invoice.model";
+import { InvoiceStatus } from "../../src/types/enums";
+
+describe("queryInvoicesPage", () => {
+  let mockDataSource: jest.Mocked<DataSource>;
+  let mockRepository: jest.Mocked<Repository<Invoice>>;
+  let mockQueryBuilder: jest.Mocked<SelectQueryBuilder<Invoice>>;
+
+  function makeInvoice(overrides: Partial<Invoice> = {}): Invoice {
+    return {
+      id: "invoice-1",
+      sellerId: "seller-1",
+      invoiceNumber: "INV-001",
+      status: InvoiceStatus.PUBLISHED,
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      ...overrides,
+    } as Invoice;
+  }
+
+  beforeEach(() => {
+    mockQueryBuilder = {
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      orderBy: jest.fn(),
+      addOrderBy: jest.fn(),
+      take: jest.fn(),
+      getMany: jest.fn(),
+    } as any;
+
+    mockQueryBuilder.where.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.andWhere.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.orderBy.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.addOrderBy.mockReturnValue(mockQueryBuilder);
+    mockQueryBuilder.take.mockReturnValue(mockQueryBuilder);
+
+    mockRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+    } as any;
+
+    mockDataSource = Object.assign(Object.create(DataSource.prototype), {
+      getRepository: jest.fn().mockReturnValue(mockRepository),
+    });
+  });
+
+  it("returns the first page ordered by created_at desc when cursor is null", async () => {
+    const invoices = [makeInvoice({ id: "1" }), makeInvoice({ id: "2" })];
+    mockQueryBuilder.getMany.mockResolvedValue(invoices);
+
+    const result = await queryInvoicesPage({}, null, 2, mockDataSource);
+
+    expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith("invoice.createdAt", "DESC");
+    expect(mockQueryBuilder.addOrderBy).toHaveBeenCalledWith("invoice.id", "DESC");
+    expect(mockQueryBuilder.take).toHaveBeenCalledWith(3);
+    expect(result.data).toHaveLength(2);
+    expect(result.has_more).toBe(false);
+  });
+
+  it("returns results strictly after the cursor position", async () => {
+    const cursor = Buffer.from("2024-01-01T00:00:00.000Z|invoice-5").toString("base64");
+    mockQueryBuilder.getMany.mockResolvedValue([makeInvoice({ id: "6" })]);
+
+    await queryInvoicesPage({}, cursor, 10, mockRepository);
+
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+      "(invoice.createdAt < :createdAt OR (invoice.createdAt = :createdAt AND invoice.id < :id))",
+      { createdAt: new Date("2024-01-01T00:00:00.000Z"), id: "invoice-5" },
+    );
+  });
+
+  it("sets has_more: false when the page is not full", async () => {
+    mockQueryBuilder.getMany.mockResolvedValue([makeInvoice()]);
+
+    const result = await queryInvoicesPage({}, null, 5, mockDataSource);
+
+    expect(result.has_more).toBe(false);
+    expect(result.next_cursor).not.toBeNull();
+  });
+
+  it("sets has_more: true and trims the extra row when more results exist", async () => {
+    const invoices = [makeInvoice({ id: "1" }), makeInvoice({ id: "2" }), makeInvoice({ id: "3" })];
+    mockQueryBuilder.getMany.mockResolvedValue(invoices);
+
+    const result = await queryInvoicesPage({}, null, 2, mockDataSource);
+
+    expect(result.has_more).toBe(true);
+    expect(result.data).toHaveLength(2);
+    expect(result.data.map((i) => i.id)).toEqual(["1", "2"]);
+  });
+
+  it("never returns the same invoice across two consecutive pages", async () => {
+    const page1Invoices = [
+      makeInvoice({ id: "1", createdAt: new Date("2024-01-03T00:00:00.000Z") }),
+      makeInvoice({ id: "2", createdAt: new Date("2024-01-02T00:00:00.000Z") }),
+      makeInvoice({ id: "3", createdAt: new Date("2024-01-01T00:00:00.000Z") }),
+    ];
+    mockQueryBuilder.getMany.mockResolvedValueOnce(page1Invoices);
+
+    const page1 = await queryInvoicesPage({}, null, 2, mockDataSource);
+    expect(page1.data.map((i) => i.id)).toEqual(["1", "2"]);
+    expect(page1.has_more).toBe(true);
+    expect(page1.next_cursor).not.toBeNull();
+
+    mockQueryBuilder.getMany.mockResolvedValueOnce([page1Invoices[2]]);
+    const page2 = await queryInvoicesPage({}, page1.next_cursor, 2, mockDataSource);
+
+    expect(page2.data.map((i) => i.id)).toEqual(["3"]);
+    expect(page2.has_more).toBe(false);
+    const page1Ids = new Set(page1.data.map((i) => i.id));
+    expect(page2.data.some((i) => page1Ids.has(i.id))).toBe(false);
+  });
+
+  it("applies sellerId and status filters", async () => {
+    mockQueryBuilder.getMany.mockResolvedValue([]);
+
+    await queryInvoicesPage(
+      { sellerId: "seller-1", status: InvoiceStatus.FUNDED },
+      null,
+      10,
+      mockDataSource,
+    );
+
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("invoice.sellerId = :sellerId", {
+      sellerId: "seller-1",
+    });
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("invoice.status = :status", {
+      status: InvoiceStatus.FUNDED,
+    });
+  });
+
+  it("applies an array of statuses via IN clause", async () => {
+    mockQueryBuilder.getMany.mockResolvedValue([]);
+
+    await queryInvoicesPage(
+      { status: [InvoiceStatus.DRAFT, InvoiceStatus.PUBLISHED] },
+      null,
+      10,
+      mockDataSource,
+    );
+
+    expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("invoice.status IN (:...statuses)", {
+      statuses: [InvoiceStatus.DRAFT, InvoiceStatus.PUBLISHED],
+    });
+  });
+
+  it("accepts a Repository directly instead of a DataSource", async () => {
+    mockQueryBuilder.getMany.mockResolvedValue([]);
+
+    await queryInvoicesPage({}, null, 10, mockRepository);
+
+    expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith("invoice");
+    expect(mockDataSource.getRepository).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/webhook-signature.test.ts
+++ b/tests/unit/webhook-signature.test.ts
@@ -1,0 +1,61 @@
+import {
+  computeWebhookSignature,
+  verifyWebhookSignature,
+} from "../../src/utils/webhook-signature";
+
+describe("verifyWebhookSignature", () => {
+  const SECRET_A = "whsec_test_secret_a_12345";
+  const SECRET_B = "whsec_test_secret_b_67890";
+  const PAYLOAD = '{"event":"invoice.paid","amount":6000}';
+
+  it("should return true for correct payload + correct secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(verifyWebhookSignature(PAYLOAD, signature, SECRET_A)).toBe(true);
+  });
+
+  it("should return false for correct payload + wrong secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(verifyWebhookSignature(PAYLOAD, signature, SECRET_B)).toBe(false);
+  });
+
+  it("should return false for wrong payload + correct secret", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const tamperedPayload = '{"event":"invoice.paid","amount":9999}';
+    expect(verifyWebhookSignature(tamperedPayload, signature, SECRET_A)).toBe(false);
+  });
+
+  it("should return false for a completely fabricated signature", () => {
+    expect(verifyWebhookSignature(PAYLOAD, "not-a-real-signature", SECRET_A)).toBe(false);
+  });
+
+  it("should return false for empty inputs", () => {
+    expect(verifyWebhookSignature("", computeWebhookSignature(PAYLOAD, SECRET_A), SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, "", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, computeWebhookSignature(PAYLOAD, SECRET_A), "")).toBe(false);
+  });
+
+  it("should never throw an exception", () => {
+    // Various malformed inputs should all return false, never throw
+    expect(verifyWebhookSignature(PAYLOAD, "zzz", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature(PAYLOAD, "abc123", SECRET_A)).toBe(false);
+    expect(verifyWebhookSignature("{}", "0000000000000000", SECRET_A)).toBe(false);
+  });
+
+  it("should return false when signature length differs from expected", () => {
+    const signature = computeWebhookSignature(PAYLOAD, SECRET_A);
+    // Truncate the signature
+    expect(verifyWebhookSignature(PAYLOAD, signature.slice(0, 10), SECRET_A)).toBe(false);
+  });
+
+  it("should produce deterministic signatures", () => {
+    const sig1 = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const sig2 = computeWebhookSignature(PAYLOAD, SECRET_A);
+    expect(sig1).toBe(sig2);
+  });
+
+  it("should produce different signatures for different secrets", () => {
+    const sigA = computeWebhookSignature(PAYLOAD, SECRET_A);
+    const sigB = computeWebhookSignature(PAYLOAD, SECRET_B);
+    expect(sigA).not.toBe(sigB);
+  });
+});

--- a/tests/validate-invoice-for-publish.test.ts
+++ b/tests/validate-invoice-for-publish.test.ts
@@ -1,4 +1,7 @@
-import { validateInvoiceForPublish } from "../src/lib/validate-invoice-for-publish";
+import {
+  MIN_FACE_VALUE_XLM,
+  validateInvoiceForPublish,
+} from "../src/lib/validate-invoice-for-publish";
 import { Invoice } from "../src/models/Invoice.model";
 import { InvoiceStatus } from "../src/types/enums";
 
@@ -40,14 +43,28 @@ describe("validateInvoiceForPublish", () => {
     const invoice = createInvoice({ amount: "0.0000" });
     const errors = validateInvoiceForPublish(invoice);
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatchObject({ field: "amount", code: "FACE_VALUE_NOT_POSITIVE" });
+    expect(errors[0]).toMatchObject({ field: "amount", code: "FACE_VALUE_TOO_LOW" });
   });
 
-  it("returns a validation error for a negative face value", () => {
-    const invoice = createInvoice({ amount: "-100.0000" });
+  it("returns a validation error for a below-minimum face value", () => {
+    const invoice = createInvoice({ amount: "99.9999" });
     const errors = validateInvoiceForPublish(invoice);
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatchObject({ field: "amount", code: "FACE_VALUE_NOT_POSITIVE" });
+    expect(errors[0]).toMatchObject({
+      field: "amount",
+      code: "FACE_VALUE_TOO_LOW",
+      message: `Invoice face value must be at least ${MIN_FACE_VALUE_XLM.toFixed(4)} XLM.`,
+    });
+  });
+
+  it("returns no validation errors at the exact minimum face value", () => {
+    const invoice = createInvoice({ amount: MIN_FACE_VALUE_XLM.toFixed(4) });
+    expect(validateInvoiceForPublish(invoice)).toEqual([]);
+  });
+
+  it("returns no validation errors above the minimum face value", () => {
+    const invoice = createInvoice({ amount: "100.0001" });
+    expect(validateInvoiceForPublish(invoice)).toEqual([]);
   });
 
   it("returns a validation error for a due date in the past", () => {
@@ -80,7 +97,7 @@ describe("validateInvoiceForPublish", () => {
     const errors = validateInvoiceForPublish(invoice);
     expect(errors).toHaveLength(3);
     expect(errors.map((e) => e.code)).toEqual(
-      expect.arrayContaining(["FACE_VALUE_NOT_POSITIVE", "DUE_DATE_TOO_SOON", "MISSING_DOCUMENT"]),
+      expect.arrayContaining(["FACE_VALUE_TOO_LOW", "DUE_DATE_TOO_SOON", "MISSING_DOCUMENT"]),
     );
   });
 });


### PR DESCRIPTION
## Overview
- Implement auth-failure metadata (reason, truncated wallet, timestamp) attached to 401 errors
- Wire structured logging to error middleware: logs auth failures after response is sent
- Extract truncated wallet addresses from unverified JWT tokens for auth hints
- Enforce minimum face value threshold (100 XLM) for invoice publish workflow
- Add unit tests for auth-failure helper (truncation, token extraction, error classification)
- Add integration test for single-investor 100% settlement payout
- Update observability and settlement tests to cover the new flows

## Issues
Closes #73, #74, #75