### PR TITLE
Add Stellar public key validator

### DIFF
--- a/src/utils/stellar-address.utils.ts
+++ b/src/utils/stellar-address.utils.ts
@@ -1,0 +1,5 @@
+import { StrKey } from "stellar-sdk";
+
+export function isValidStellarPublicKey(address: unknown): address is string {
+  return typeof address === "string" && StrKey.isValidEd25519PublicKey(address);
+}

--- a/tests/unit/stellar-address.test.ts
+++ b/tests/unit/stellar-address.test.ts
@@ -1,0 +1,30 @@
+import { Keypair, StrKey } from "stellar-sdk";
+
+import { isValidStellarPublicKey } from "../../src/utils/stellar-address.utils";
+
+describe("isValidStellarPublicKey", () => {
+  it("returns true for a valid Stellar ed25519 public key", () => {
+    expect(isValidStellarPublicKey(Keypair.random().publicKey())).toBe(true);
+  });
+
+  it("returns false for malformed G-addresses", () => {
+    expect(isValidStellarPublicKey("GABC")).toBe(false);
+    expect(
+      isValidStellarPublicKey(
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for non-public-key StrKey values", () => {
+    const contractId = StrKey.encodeContract(Buffer.alloc(32, 1));
+
+    expect(isValidStellarPublicKey(contractId)).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect(isValidStellarPublicKey(null)).toBe(false);
+    expect(isValidStellarPublicKey(undefined)).toBe(false);
+    expect(isValidStellarPublicKey(123)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- Added `isValidStellarPublicKey` in `src/utils/stellar-address.utils.ts`.
- Added unit coverage for valid ed25519 G-addresses, malformed values, non-public-key StrKeys, and non-string input.

## Validation
- `npm test -- --runTestsByPath tests/unit/stellar-address.test.ts`
- `npm run type-check`
- `npm run lint`

Closes #162