### PR TITLE
Add platform fee calculation coverage

### DIFF
--- a/src/utils/fee-calculator.utils.ts
+++ b/src/utils/fee-calculator.utils.ts
@@ -1,0 +1,14 @@
+import Decimal from "decimal.js";
+
+const BASIS_POINTS_DIVISOR = new Decimal(10_000);
+const MONEY_DECIMAL_PLACES = 2;
+
+export function calculatePlatformFee(
+  amount: Decimal,
+  feeBps: number,
+): Decimal {
+  return amount
+    .mul(feeBps)
+    .div(BASIS_POINTS_DIVISOR)
+    .toDecimalPlaces(MONEY_DECIMAL_PLACES, Decimal.ROUND_HALF_UP);
+}

--- a/tests/unit/utils/fee-calculator.test.ts
+++ b/tests/unit/utils/fee-calculator.test.ts
@@ -1,0 +1,30 @@
+import Decimal from "decimal.js";
+
+import { calculatePlatformFee } from "../../../src/utils/fee-calculator.utils";
+
+describe("calculatePlatformFee", () => {
+  it("returns zero for 0 bps", () => {
+    expect(calculatePlatformFee(new Decimal(1000), 0).equals(new Decimal(0))).toBe(true);
+  });
+
+  it("calculates 50 bps as 0.5%", () => {
+    expect(calculatePlatformFee(new Decimal(1000), 50).equals(new Decimal(5))).toBe(true);
+  });
+
+  it("calculates 150 bps as 1.5%", () => {
+    expect(calculatePlatformFee(new Decimal(1000), 150).equals(new Decimal(15))).toBe(true);
+  });
+
+  it("calculates 250 bps as 2.5%", () => {
+    expect(calculatePlatformFee(new Decimal(1000), 250).equals(new Decimal(25))).toBe(true);
+  });
+
+  it("calculates 10000 bps as 100%", () => {
+    expect(calculatePlatformFee(new Decimal(1000), 10_000).equals(new Decimal(1000))).toBe(true);
+  });
+
+  it("rounds half up to currency precision", () => {
+    expect(calculatePlatformFee(new Decimal("10.005"), 10_000).toFixed(2)).toBe("10.01");
+    expect(calculatePlatformFee(new Decimal("10.004"), 10_000).toFixed(2)).toBe("10.00");
+  });
+});


### PR DESCRIPTION
## What changed
- Added `calculatePlatformFee` for basis-point platform fee calculations.
- Added unit tests for 0, 50, 150, 250, and 10000 bps.
- Covered Decimal.js `ROUND_HALF_UP` behavior at currency precision.

## Validation
- `npm test -- --runTestsByPath tests/unit/utils/fee-calculator.test.ts`
- `npm run type-check`
- `npm run lint`

Closes #165