### PR TITLE
Cover missing auth header rejection

### DIFF
--- a/tests/integration/auth-jwt-validation.test.ts
+++ b/tests/integration/auth-jwt-validation.test.ts
@@ -1,0 +1,47 @@
+import express from "express";
+import request from "supertest";
+
+import { createErrorMiddleware } from "../../src/middleware/error.middleware";
+import { logger } from "../../src/observability/logger";
+import { createInvoiceRouter } from "../../src/routes/invoice.routes";
+
+describe("JWT authentication validation", () => {
+  it("rejects invoice requests without an Authorization header", async () => {
+    const invoiceService = {
+      getInvoicesBySellerId: jest.fn(),
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(
+      "/api/v1/invoices",
+      createInvoiceRouter({
+        invoiceService: invoiceService as any,
+        config: {
+          ipfs: {
+            maxFileSizeMB: 10,
+            allowedMimeTypes: ["application/pdf"],
+            uploadRateLimit: {
+              windowMs: 60_000,
+              maxUploads: 5,
+            },
+          },
+          kyc: {
+            skipVerification: true,
+          },
+        } as any,
+      }),
+    );
+    app.use(createErrorMiddleware(logger));
+
+    const response = await request(app).get("/api/v1/invoices").expect(401);
+
+    expect(response.body).toMatchObject({
+      success: false,
+      error: {
+        message: "Authorization token is required.",
+      },
+    });
+    expect(invoiceService.getInvoicesBySellerId).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed
- Added integration coverage for protected invoice requests sent without an `Authorization` header.
- Verifies the existing 401 response shape and confirms invoice service logic is not invoked when auth is missing.

## Note
The issue text references `/api/invoices` and `Authentication header missing`; this project currently exposes invoices under `/api/v1/invoices` and uses the existing error message `Authorization token is required.`. This PR tests the current API behavior without changing the response contract.

## Validation
- `npm test -- --runTestsByPath tests/integration/auth-jwt-validation.test.ts`
- `npm run type-check`
- `npm run lint`

Closes #171