### PR TITLE
Add Soroban contract ID validator

### DIFF
--- a/src/lib/stellar-address.ts
+++ b/src/lib/stellar-address.ts
@@ -1,0 +1,15 @@
+import { StrKey } from "stellar-sdk";
+
+export function isValidStellarPublicKey(value: unknown): value is string {
+  return typeof value === "string" && StrKey.isValidEd25519PublicKey(value);
+}
+
+export function isValidSorobanContractId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    StrKey.decodeContract(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/unit/stellar-address.test.ts
+++ b/tests/unit/stellar-address.test.ts
@@ -1,0 +1,33 @@
+import { Keypair, StrKey } from "stellar-sdk";
+import {
+  isValidSorobanContractId,
+  isValidStellarPublicKey,
+} from "../../src/lib/stellar-address";
+
+describe("stellar address validators", () => {
+  it("accepts a valid Soroban contract C-address", () => {
+    const contractId = StrKey.encodeContract(Buffer.alloc(32, 7));
+
+    expect(isValidSorobanContractId(contractId)).toBe(true);
+  });
+
+  it("rejects Stellar public keys when a Soroban contract ID is required", () => {
+    expect(isValidSorobanContractId(Keypair.random().publicKey())).toBe(false);
+  });
+
+  it("rejects malformed or non-string contract IDs", () => {
+    expect(isValidSorobanContractId("CNOT-A-VALID-CONTRACT")).toBe(false);
+    expect(isValidSorobanContractId("")).toBe(false);
+    expect(isValidSorobanContractId(null)).toBe(false);
+    expect(isValidSorobanContractId(undefined)).toBe(false);
+    expect(isValidSorobanContractId(123)).toBe(false);
+  });
+
+  it("keeps Stellar public key validation separate from contract IDs", () => {
+    const publicKey = Keypair.random().publicKey();
+    const contractId = StrKey.encodeContract(Buffer.alloc(32, 8));
+
+    expect(isValidStellarPublicKey(publicKey)).toBe(true);
+    expect(isValidStellarPublicKey(contractId)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Stellar address validators for public keys and Soroban contract C-addresses
- validate Soroban contract IDs via `StrKey.decodeContract()` so invalid C-address inputs are rejected without relying on an untyped runtime helper
- add focused unit coverage for valid contract IDs, malformed/non-string inputs, and public-key-vs-contract separation

Closes #163.

## Validation
- `npm test -- tests/unit/stellar-address.test.ts` -> 1 suite / 4 tests passed
- `npm run type-check` -> passed
- `npm run build` -> passed
- `npm run lint` -> passed
- `git diff --check` -> passed

## Payout
This is Stellar Wave / USDC-compatible. EVM/Base USDC address: `0x2f8081562ac67467d1cbd40ab3120849c1f587da`.

If payment must be Stellar-native USDC, please ask for a Stellar public key before sending.
