### PR TITLE
feat: add TypeORM migrations for webhook_subscriptions, soroban_event_logs and index

### DIFF
--- a/src/migrations/1712000000000-CreateWebhookSubscriptionsTable.ts
+++ b/src/migrations/1712000000000-CreateWebhookSubscriptionsTable.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateWebhookSubscriptionsTable1712000000000
+  implements MigrationInterface
+{
+  name = "CreateWebhookSubscriptionsTable1712000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "webhook_subscriptions" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "user_id" uuid NOT NULL,
+        "url" character varying(255) NOT NULL,
+        "secret" character varying(64) NOT NULL,
+        "event_types" jsonb NOT NULL,
+        "active" boolean NOT NULL DEFAULT true,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_webhook_subscriptions" PRIMARY KEY ("id")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "idx_webhook_subscriptions_user_id"
+      ON "webhook_subscriptions" ("user_id");
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "webhook_subscriptions"
+      ADD CONSTRAINT "FK_webhook_subscriptions_user"
+      FOREIGN KEY ("user_id") REFERENCES "users"("id")
+      ON DELETE CASCADE;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "webhook_subscriptions"
+      DROP CONSTRAINT "FK_webhook_subscriptions_user";
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."idx_webhook_subscriptions_user_id";
+    `);
+
+    await queryRunner.query(`DROP TABLE "webhook_subscriptions"`);
+  }
+}

--- a/src/migrations/1713000000000-CreateSorobanEventLogsTable.ts
+++ b/src/migrations/1713000000000-CreateSorobanEventLogsTable.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateSorobanEventLogsTable1713000000000
+  implements MigrationInterface
+{
+  name = "CreateSorobanEventLogsTable1713000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "soroban_event_logs" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "contract_id" character varying(56) NOT NULL,
+        "ledger_sequence" bigint NOT NULL,
+        "topic" character varying(64) NOT NULL,
+        "tx_hash" character varying(64) NOT NULL,
+        "payload" jsonb,
+        "processed" boolean NOT NULL DEFAULT false,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_soroban_event_logs" PRIMARY KEY ("id")
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "idx_soroban_event_logs_processed"
+      ON "soroban_event_logs" ("processed");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "public"."idx_soroban_event_logs_processed";
+    `);
+
+    await queryRunner.query(`DROP TABLE "soroban_event_logs"`);
+  }
+}

--- a/src/migrations/1714000000000-AddSorobanEventLogsIndex.ts
+++ b/src/migrations/1714000000000-AddSorobanEventLogsIndex.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSorobanEventLogsIndex1714000000000
+  implements MigrationInterface
+{
+  name = "AddSorobanEventLogsIndex1714000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX "IDX_SOROBAN_EVENTS_CONTRACT_LEDGER"
+      ON "soroban_event_logs" ("contract_id", "ledger_sequence" DESC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX "public"."IDX_SOROBAN_EVENTS_CONTRACT_LEDGER";
+    `);
+  }
+}

--- a/src/models/SorobanEventLog.model.ts
+++ b/src/models/SorobanEventLog.model.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+@Entity("soroban_event_logs")
+export class SorobanEventLog {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ name: "contract_id", type: "varchar", length: 56 })
+  contractId!: string;
+
+  @Column({ name: "ledger_sequence", type: "bigint" })
+  ledgerSequence!: string;
+
+  @Column({ type: "varchar", length: 64 })
+  topic!: string;
+
+  @Column({ name: "tx_hash", type: "varchar", length: 64 })
+  txHash!: string;
+
+  @Column({ type: "jsonb", nullable: true })
+  payload!: Record<string, unknown> | null;
+
+  @Column({ type: "boolean", default: false })
+  @Index("idx_soroban_event_logs_processed")
+  processed!: boolean;
+
+  @CreateDateColumn({ name: "created_at", type: "timestamptz" })
+  createdAt!: Date;
+}

--- a/src/models/WebhookSubscription.model.ts
+++ b/src/models/WebhookSubscription.model.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import type { User } from "./User.model";
+
+@Entity("webhook_subscriptions")
+export class WebhookSubscription {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ name: "user_id", type: "uuid" })
+  @Index("idx_webhook_subscriptions_user_id")
+  userId!: string;
+
+  @Column({ type: "varchar", length: 255 })
+  url!: string;
+
+  @Column({ type: "varchar", length: 64 })
+  secret!: string;
+
+  @Column({ name: "event_types", type: "jsonb" })
+  eventTypes!: string[];
+
+  @Column({ type: "boolean", default: true })
+  active!: boolean;
+
+  @CreateDateColumn({ name: "created_at", type: "timestamptz" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at", type: "timestamptz" })
+  updatedAt!: Date;
+
+  @ManyToOne("User", { onDelete: "CASCADE" })
+  @JoinColumn({ name: "user_id" })
+  user!: User;
+}


### PR DESCRIPTION
- Add `webhook_subscriptions` table migration with `user_id` FK to `users(id)` (ON DELETE CASCADE), `url`, `secret`, `event_types` (jsonb), `active`, timestamps, plus a `WebhookSubscription` entity model.
- Add `soroban_event_logs` table migration with `contract_id`, `ledger_sequence` (bigint), `topic`, `tx_hash`, `payload` (jsonb), `processed`, `created_at`, plus a `SorobanEventLog` entity model.
- Add composite index `IDX_SOROBAN_EVENTS_CONTRACT_LEDGER` on `soroban_event_logs (contract_id, ledger_sequence DESC)` in its own migration, ordered after the table-creation migration.

Migration timestamps are ordered so TypeORM runs them in the correct sequence: webhook_subscriptions table → soroban_event_logs table → composite index.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint src/**/*.ts` — clean (also runs via pre-commit hook)
- [x] `npx jest` — 400/401 passing; 1 pre-existing failure in `tests/validate-invoice-for-publish.test.ts` unrelated to this change (invoice validation error ordering), left untouched
- [ ] Migration up/down verified against a live Postgres instance (not run — no local DB available in this environment; migrations follow the exact raw-SQL style of existing migrations in `src/migrations`)

Closes #168
Closes #167
Closes #166